### PR TITLE
整理依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,24 +25,26 @@
     "pub:doc": "father doc build && father doc deploy"
   },
   "dependencies": {
-    "antd": "^3.20.1",
-    "react-drag-listview": "^0.1.6",
     "react-use": "^10.6.2",
-    "regenerator-runtime": "^0.13.3",
-    "umi-request": "^1.0.8"
+    "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "antd": "^3.20.1",
+    "react": "^16.8.6"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^2.0.1",
     "@types/jest": "^24.0.15",
+    "antd": "^3.20.1",
     "babel-plugin-import": "^1.12.0",
     "docz-theme-ztopia": "^0.0.27",
     "enzyme": "^3.10.0",
     "father": "^2.13.3",
-    "typescript": "^3.3.3"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-drag-listview": "^0.1.6",
+    "typescript": "^3.3.3",
+    "umi-request": "^1.0.8"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
- 没有依赖 react-dom 不应该放 peerDependencies 里。
- 运行时没有依赖 antd、react-drag-listview、umi-request 不应该放 dependencies 里。

另外 peerDependencies 的依赖是不会安装的，开发是要用的话 devDependencies 里也要写。