### PR TITLE
remove the side effects of useResponsive

### DIFF
--- a/src/useResponsive/index.ts
+++ b/src/useResponsive/index.ts
@@ -11,6 +11,8 @@ interface ResponsiveInfo {
   [key: string]: boolean;
 }
 
+let info: ResponsiveInfo;
+
 let responsiveConfig: ResponsiveConfig = {
   xs: 0,
   sm: 576,
@@ -19,12 +21,19 @@ let responsiveConfig: ResponsiveConfig = {
   xl: 1200,
 };
 
-export function configResponsive(config: ResponsiveConfig) {
-  responsiveConfig = config;
+function init() {
+  if (info) return;
+  info = {};
   calculate();
+  window.addEventListener('resize', () => {
+    const oldInfo = info;
+    calculate();
+    if (oldInfo === info) return;
+    for (const subscriber of subscribers) {
+      subscriber();
+    }
+  });
 }
-
-let info: ResponsiveInfo = {};
 
 function calculate() {
   const width = window.innerWidth;
@@ -40,18 +49,14 @@ function calculate() {
     info = newInfo;
   }
 }
-calculate();
 
-window.addEventListener('resize', () => {
-  const oldInfo = info;
-  calculate();
-  if (oldInfo === info) return;
-  for (const subscriber of subscribers) {
-    subscriber();
-  }
-});
+export function configResponsive(config: ResponsiveConfig) {
+  responsiveConfig = config;
+  if (info) calculate();
+}
 
 export function useResponsive() {
+  init();
   const [state, setState] = useState<ResponsiveInfo>(info);
 
   useEffect(() => {


### PR DESCRIPTION
之前的 `index.ts` 包含了副作用，由于被最顶层的 `index.ts` 引用了，导致用户即便没有 `import {useResponsive} from '@umi/hooks'` ，也会执行 `useResponsive/index.ts` 中的副作用。
现在把这些副作用封在了 `init` 函数中，只有在执行 `useReponsive()` 后，才会真的执行这些副作用。