### PR TITLE
fix: use subscription Array instead of Set

### DIFF
--- a/src/useEventEmitter/index.ts
+++ b/src/useEventEmitter/index.ts
@@ -3,7 +3,7 @@ import { useRef, useEffect } from 'react';
 type Subscription<T> = (val: T) => void;
 
 export class EventEmitter<T> {
-  private subscriptions = new Set<Subscription<T>>();
+  private subscriptions: Subscription<T>[] = [];
 
   emit = (val: T) => {
     for (const subscription of this.subscriptions) {
@@ -20,9 +20,10 @@ export class EventEmitter<T> {
           callbackRef.current(val);
         }
       }
-      this.subscriptions.add(subscription);
+      this.subscriptions.push(subscription);
       return () => {
-        this.subscriptions.delete(subscription);
+        const idx = this.subscriptions.indexOf(subscription);
+        this.subscriptions.splice(idx, 1);
       };
     }, []);
   };


### PR DESCRIPTION
没道理用 Set 。。。

1. 应该允许一个函数（指引用相同）重复注册
2. 保持注册顺序和触发顺序一致才有可能做到 pipe 之类的功能

--------

建议这个 hook 改名，这不叫 EE，EE 应该是一个 bus，而这只是单一 observable value，
这个更确切的说是 reactive，而不是发布订阅。。。