### PR TITLE
fix: useAntdTable support antd@4.x form

### DIFF
--- a/src/useAntdTable/index.ts
+++ b/src/useAntdTable/index.ts
@@ -260,7 +260,7 @@ function useAntdTable<Result, Item>(
     const targetFormData = { ...state.formData, ...tempFieldsValueRef.current };
     const existFormData: FormData = {};
     Object.keys(targetFormData).forEach((key: string) => {
-      if (form.getFieldInstance && form.getFieldInstance(key)) {
+      if (form.getFieldInstance ? form.getFieldInstance(key) : true) {
         existFormData[key] = targetFormData[key];
       }
     });
@@ -276,7 +276,7 @@ function useAntdTable<Result, Item>(
     const fieldsValue = form.getFieldsValue();
     const filterFiledsValue: FormData = {};
     Object.keys(fieldsValue).forEach((key: string) => {
-      if (form.getFieldInstance && form.getFieldInstance(key)) {
+      if (form.getFieldInstance ? form.getFieldInstance(key) : true) {
         filterFiledsValue[key] = fieldsValue[key];
       }
     });


### PR DESCRIPTION
`antd@4.x` form 已经没有 `getFieldInstance` API，在 `antd@4.x` `form` 中自测可行。