### PR TITLE
useAntdTable: Extend pagination definition

### DIFF
--- a/src/useAntdTable/index.ts
+++ b/src/useAntdTable/index.ts
@@ -14,7 +14,6 @@ import isEqual from 'lodash.isequal';
 import useAsync from '../useAsync';
 import useUpdateEffect from '../useUpdateEffect';
 
-
 interface UseAntdTableFormUtils extends WrappedFormUtils {
   getFieldInstance?: (name: string) => {};
 }
@@ -33,7 +32,7 @@ export interface ReturnValue<Item> {
       current: number;
       pageSize: number;
       total: number;
-    };
+    } & { [K in keyof PaginationConfig]?: PaginationConfig[K] };
   };
   tableProps: {
     dataSource: Item[];
@@ -47,7 +46,7 @@ export interface ReturnValue<Item> {
       current: number;
       pageSize: number;
       total: number;
-    };
+    } & { [K in keyof PaginationConfig]?: PaginationConfig[K] };
   };
   sorter: SorterResult<Item>;
   filters: Record<keyof Item, string[]>;


### PR DESCRIPTION
Extend the pagination definition with the other existing keys in `PaginationConfig` marking it as optional, so the example in Remarks section compiles in typescript.

https://hooks.umijs.org/useAntdTable#remarks

For the future, this is the code in plain javascript shown in the example of the remarks section:

```js
import { useAntdTable } from '@umijs/hooks'

export default (fn, deps = [], options = {}) => {
  const result = useAntdTable(fn, deps, {
    formatResult: res => ({
      total: res.data.pagination.total,
      data: res.data.list,
    }),
    ...options,
  })
  result.tableProps.pagination.showQuickJumper = true
  result.tableProps.pagination.showSizeChanger = true
  result.tableProps.pagination.hideOnSinglePage = true
  result.tableProps.pagination.showTotal = total => `共 ${total} 条`
  return result
}
```

The typescript complains that `hideOnSinglePage, showTotal, ...` props doesn't exists in the `pagination` object.
