### PR TITLE
chore: remove antd as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "antd": "^3.26.6",
     "react": "^16.8.6"
   },
   "devDependencies": {

--- a/src/useAntdTable/typings.ts
+++ b/src/useAntdTable/typings.ts
@@ -34,10 +34,5 @@ export interface PaginationConfig {
   [key: string]: any;
 }
 
-export interface SorterItem {
-  column: any;
-  order: 'ascend' | 'descend' | undefined;
-  field: string;
-  columnKey: string | undefined;
-  [key: string]: any;
-}
+export type Sorter = any;
+export type Filter = any;

--- a/src/useAntdTable/typings.ts
+++ b/src/useAntdTable/typings.ts
@@ -1,0 +1,43 @@
+export interface PaginationConfig {
+  total?: number;
+  defaultCurrent?: number;
+  disabled?: boolean;
+  current?: number;
+  defaultPageSize?: number;
+  pageSize?: number;
+  onChange?: (page: number, pageSize?: number) => void;
+  hideOnSinglePage?: boolean;
+  showSizeChanger?: boolean;
+  pageSizeOptions?: string[];
+  onShowSizeChange?: (current: number, size: number) => void;
+  showQuickJumper?:
+    | boolean
+    | {
+        goButton?: React.ReactNode;
+      };
+  showTotal?: (total: number, range: [number, number]) => React.ReactNode;
+  size?: string;
+  simple?: boolean;
+  style?: React.CSSProperties;
+  locale?: Object;
+  className?: string;
+  prefixCls?: string;
+  selectPrefixCls?: string;
+  itemRender?: (
+    page: number,
+    type: 'page' | 'prev' | 'next' | 'jump-prev' | 'jump-next',
+    originalElement: React.ReactElement<HTMLElement>,
+  ) => React.ReactNode;
+  role?: string;
+  showLessItems?: boolean;
+  position?: 'top' | 'bottom' | 'both';
+  [key: string]: any;
+}
+
+export interface SorterItem {
+  column: any;
+  order: 'ascend' | 'descend' | undefined;
+  field: string;
+  columnKey: string | undefined;
+  [key: string]: any;
+}

--- a/src/useAntdTable/typings.ts
+++ b/src/useAntdTable/typings.ts
@@ -34,5 +34,12 @@ export interface PaginationConfig {
   [key: string]: any;
 }
 
-export type Sorter = any;
+export interface Sorter {
+  column?: any;
+  order?: 'ascend' | 'descend';
+  field?: string;
+  columnKey?: string;
+  [key: string]: any;
+}
+
 export type Filter = any;


### PR DESCRIPTION
有些 antd 的类型完整搬过来会很长，涉及多个文件，就放宽了一些限制，以不会报错为主