### PR TITLE
fix(useStorageState): key change, set undefined

### DIFF
--- a/packages/hooks/src/useStorageState/__tests__/index.test.ts
+++ b/packages/hooks/src/useStorageState/__tests__/index.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useStorageState, { IFuncUpdater } from '../index';
+
+class TestStorage implements Storage {
+  [name: string]: any;
+
+  length: number = 0;
+
+  _values = new Map<string, string>();
+
+  clear(): void {
+    this._values.clear();
+    this.length = 0;
+  }
+
+  getItem(key: string): string {
+    return this._values.get(key);
+  }
+
+  key(index: number): string {
+    if (index >= this._values.size) {
+      return null;
+    }
+
+    return Array.from(this._values.keys())[index];
+  }
+
+  removeItem(key: string): void {
+    if (this._values.delete(key)) {
+      this.length -= 1;
+    }
+  }
+
+  setItem(key: string, value: string): void {
+    if (!this._values.has(key)) {
+      this.length += 1;
+    }
+
+    this._values.set(key, value);
+  }
+}
+
+interface StorageStateProps<T> {
+  key: string;
+  defaultValue?: T | IFuncUpdater<T>;
+}
+
+describe('useStorageState', () => {
+  const setUp = <T>(props: StorageStateProps<T>) => {
+    const storage = new TestStorage();
+
+    return renderHook(({ key, defaultValue }: StorageStateProps<T>) => {
+      const [state, setState] = useStorageState(storage, key, defaultValue);
+
+      return { state, setState };
+    }, {
+      initialProps: props
+    });
+  }
+
+  it('should be defined', () => {
+    expect(useStorageState);
+  });
+
+  it('should get defaultValue for a given key', () => {
+    const hook = setUp({ key: 'key1', defaultValue: 'value1' });
+    expect(hook.result.current.state).toEqual('value1');
+
+    hook.rerender({ key: 'key2', defaultValue: 'value2' });
+    expect(hook.result.current.state).toEqual('value2');
+  });
+
+  it('should get default and set value for a given key', () => {
+    const hook = setUp({ key: 'key', defaultValue: 'defaultValue' });
+    expect(hook.result.current.state).toEqual('defaultValue');
+    act(() => {
+      hook.result.current.setState('setValue');
+    });
+    expect(hook.result.current.state).toEqual('setValue');
+    hook.rerender({ key: 'key' });
+    expect(hook.result.current.state).toEqual('setValue');
+  });
+
+  it('should remove value for a given key', () => {
+    const hook = setUp({ key: 'key' });
+    act(() => {
+      hook.result.current.setState('value');
+    });
+    expect(hook.result.current.state).toEqual('value');
+    act(() => {
+      hook.result.current.setState(undefined);
+    });
+    expect(hook.result.current.state).toBeUndefined();
+  });
+});

--- a/packages/hooks/src/useStorageState/index.ts
+++ b/packages/hooks/src/useStorageState/index.ts
@@ -1,14 +1,23 @@
 import { useState } from 'react';
+import useUpdateEffect from '../useUpdateEffect';
 
-interface IFuncUpdater<T> {
+export interface IFuncUpdater<T> {
   (previousState?: T): T;
 }
+
+export type StorageStateDefaultValue<T> = T | IFuncUpdater<T>;
+
+export type StorageStateResult<T> = [T | undefined, (value: StorageStateDefaultValue<T>) => void];
 
 function isFunction<T>(obj: any): obj is T {
   return typeof obj === 'function';
 }
 
-function useStorageState<T>(storage: Storage, key: string, defaultValue?: T | IFuncUpdater<T>) {
+function useStorageState<T>(
+  storage: Storage,
+  key: string,
+  defaultValue?: StorageStateDefaultValue<T>
+): StorageStateResult<T> {
   const [state, setState] = useState<T | undefined>(() => getStoredValue());
 
   function getStoredValue() {
@@ -25,7 +34,7 @@ function useStorageState<T>(storage: Storage, key: string, defaultValue?: T | IF
   function updateState(value?: T | IFuncUpdater<T>) {
     if (typeof value === 'undefined') {
       storage.removeItem(key);
-      setState(defaultValue);
+      setState(undefined);
     } else if (isFunction<IFuncUpdater<T>>(value)) {
       const previousState = getStoredValue();
       const currentState = value(previousState);
@@ -36,6 +45,11 @@ function useStorageState<T>(storage: Storage, key: string, defaultValue?: T | IF
       setState(value);
     }
   }
+
+  useUpdateEffect(() => {
+    setState(getStoredValue());
+  }, [key]);
+
   return [state, updateState];
 }
 


### PR DESCRIPTION
When the key changes storage  should set a new state according
to a given key value.

When removing item from store state should be set to `undefined`
as default value can be of multiple types.

Changes:
- add StorageStateDefaultValue and StorageStateResult  types for clarity
- add explicit return type (avoids using `as const` construct)
- add tests