### PR TITLE
Remove deprecated hook from usage instruction of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm i @umijs/hooks --save
 ## 🔨 Usage
 
 ```
-import { useAsync } from '@umijs/hooks';
+import { useRequest } from '@umijs/hooks';
 ```
 
 ## 🖥 Development


### PR DESCRIPTION
Based on the fact that `useAsync` is deprecated, I suggest to remove their references from the usage section of `README.md`.