### PR TITLE
解决 demo3.tsx 中 PaginatedParams 的引入报错问题，版本 1.7.1

### DIFF
--- a/packages/hooks/src/useFormTable/demo/demo3.tsx
+++ b/packages/hooks/src/useFormTable/demo/demo3.tsx
@@ -8,9 +8,8 @@
 
 import React from 'react';
 import { Button, Col, Form, Input, Row, Table, Select } from 'antd';
-// import { useFormTable } from '@umijs/hooks'
-import useFormTable, { PaginatedParams } from '..';
-// import { PaginatedParams } from '@umijs/hooks/useFormTable/lib'
+import { useFormTable } from '@umijs/hooks';
+import { PaginatedParams } from '@umijs/hooks/lib/useFormTable';
 
 const { Option } = Select;
 


### PR DESCRIPTION
Cannot find module '@umijs/hooks/useFormTable/lib'