### PR TITLE
fix: Duplicate object key in now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -11,9 +11,6 @@
       }
     }
   ],
-  "github": {
-    "enabled": false
-  },
   "routes": [
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }


### PR DESCRIPTION
There are two same keys in `now.json` , and both has same values,  so remove one of them.