### PR TITLE
refactor: improve type inference of useSessionStorageState and useLoc…

### DIFF
--- a/packages/hooks/src/useLocalStorageState/index.ts
+++ b/packages/hooks/src/useLocalStorageState/index.ts
@@ -7,7 +7,7 @@ function useLocalStorageState<T = undefined>(
 function useLocalStorageState<T>(
   key: string,
   defaultValue: T | (() => T),
-): [T, (value?: T | ((previousState?: T) => T)) => void];
+): [T, (value?: T | ((previousState: T) => T)) => void];
 
 function useLocalStorageState<T>(key: string, defaultValue?: T | (() => T)) {
   return useStorageState(localStorage, key, defaultValue);

--- a/packages/hooks/src/useSessionStorageState/index.ts
+++ b/packages/hooks/src/useSessionStorageState/index.ts
@@ -7,7 +7,7 @@ function useSessionStorageState<T = undefined>(
 function useSessionStorageState<T>(
   key: string,
   defaultValue: T | (() => T),
-): [T, (value?: T | ((previousState?: T) => T)) => void];
+): [T, (value?: T | ((previousState: T) => T)) => void];
 
 function useSessionStorageState<T>(key: string, defaultValue?: T | (() => T)) {
   return useStorageState(sessionStorage, key, defaultValue);


### PR DESCRIPTION
当提供了 `defaultValue` 时，`previousState` 不应该会有 `undefined` 的可能。例如：

```typescript
const [age, setAge] = useLocalStorageState<number>('age', 1)

// 这种case 不应该提示警告说 s 可能为 undefined
setAge(s => a + 10)
```