### PR TITLE
fix(useControllableValue): remove the extra memo

### DIFF
--- a/packages/hooks/src/useControllableValue/index.ts
+++ b/packages/hooks/src/useControllableValue/index.ts
@@ -22,7 +22,7 @@ export default function useControllableValue<T>(props: Props = {}, options: Opti
 
   const value = props[valuePropName];
 
-  const initialValue = useMemo(() => {
+  const initialValue = () => {
     if (valuePropName in props) {
       return value;
     }
@@ -30,7 +30,7 @@ export default function useControllableValue<T>(props: Props = {}, options: Opti
       return props[defaultValuePropName];
     }
     return defaultValue;
-  }, []);
+  }
 
   const [state, setState] = useState<T | undefined>(initialValue);
 


### PR DESCRIPTION
https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
参考官方文档，init 时候没有必要使用 memo