### PR TITLE
Converted useLayoutEffect to useEffect due to proper SSR usage

### DIFF
--- a/packages/hooks/src/useInViewport/index.ts
+++ b/packages/hooks/src/useInViewport/index.ts
@@ -32,7 +32,7 @@ function useInViewport(target: Target): InViewport {
     return isInViewPort(el as HTMLElement);
   });
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const el = getTargetElement(target);
     if (!el) {
       return () => {};


### PR DESCRIPTION
Removes warning and preserve functionality when using React SSR:
  
Warning: useLayoutEffect does nothing on the server because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://fb.me/react-uselayouteffect-ssr for common fixes.