### PR TITLE
feat: add `useVisibleRatio` hooks

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -33,7 +33,7 @@ import useFusionTable from './useFusionTable';
 import useSet from './useSet';
 import usePersistFn from './usePersistFn';
 import useMap from './useMap';
-import useCreation from './useCreation'
+import useCreation from './useCreation';
 import { useDrag, useDrop } from './useDrop';
 import useMount from './useMount';
 import useTextSelection from './useTextSelection';
@@ -42,6 +42,7 @@ import useUpdate from './useUpdate';
 import useEventTarget from './useEventTarget';
 import useHistoryTravel from './useHistoryTravel';
 import useDebounceEffect from './useDebounceEffect';
+import useVisibleRatio from './useVisibleRatio';
 
 const useControlledValue: typeof useControllableValue = function (...args) {
   console.warn(
@@ -97,5 +98,6 @@ export {
   useTextSelection,
   useEventTarget,
   useHistoryTravel,
-  useFusionTable
+  useFusionTable,
+  useVisibleRatio,
 };

--- a/packages/hooks/src/useVisibleRatio/__tests__/index.test.ts
+++ b/packages/hooks/src/useVisibleRatio/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useVisibleRatio from '../index';
+
+describe('useVisibleRatio', () => {
+  it('should be defined', () => {
+    expect(useVisibleRatio).toBeDefined();
+  });
+
+  it('with argument', () => {
+    const hook = renderHook(() => useVisibleRatio(document.body));
+    expect(hook.result.current).toEqual(0);
+  });
+
+  it("returns value's type should be number", () => {
+    const hook = renderHook(() => useVisibleRatio(document.body));
+    expect(hook.result.current).toEqual(0);
+  });
+});

--- a/packages/hooks/src/useVisibleRatio/demo/demo1.tsx
+++ b/packages/hooks/src/useVisibleRatio/demo/demo1.tsx
@@ -1,0 +1,25 @@
+/**
+ * title: Default usage
+ * desc: Using ref to listen to visible part ratio value of the node.
+ *
+ * title.zh-CN: 基本用法
+ * desc.zh-CN: 使用 ref 监听节点在视图变化或者滚动时的可视区域百分比
+ */
+
+import React, { useRef } from 'react';
+import { useVisibleRatio } from 'ahooks';
+
+export default () => {
+  const ref = useRef();
+  const visibleRatio = useVisibleRatio(ref);
+  return (
+    <div>
+      <div ref={ref} style={{ height: 200 }}>
+        observer dom
+      </div>
+      <div style={{ marginTop: 70, color: visibleRatio > 0 ? '#87d068' : '#f50' }}>
+        {visibleRatio}
+      </div>
+    </div>
+  );
+};

--- a/packages/hooks/src/useVisibleRatio/demo/demo2.tsx
+++ b/packages/hooks/src/useVisibleRatio/demo/demo2.tsx
@@ -1,0 +1,24 @@
+/**
+ * title: Pass in DOM element
+ * desc: Pass in a function that returns the DOM element.
+ *
+ * title.zh-CN: 传入 DOM 元素
+ * desc.zh-CN: 传入 function 并返回一个 dom 元素
+ */
+
+import React from 'react';
+import { useVisibleRatio } from 'ahooks';
+
+export default () => {
+  const visibleRatio = useVisibleRatio(() => document.querySelector('#demo2'));
+  return (
+    <div>
+      <div id="demo2" style={{ height: 200 }}>
+        observer dom
+      </div>
+      <div style={{ marginTop: 70, color: visibleRatio > 0 ? '#87d068' : '#f50' }}>
+        {visibleRatio}
+      </div>
+    </div>
+  );
+};

--- a/packages/hooks/src/useVisibleRatio/index.en-US.md
+++ b/packages/hooks/src/useVisibleRatio/index.en-US.md
@@ -1,0 +1,43 @@
+---
+title: useVisibleRatio
+nav:
+  title: Hooks
+  path: /hooks
+group:
+  title: Dom
+  path: /dom
+legacy: /dom/use-visible-ratio
+---
+
+# useVisibleRatio
+
+A hook to subscribe the visible part ratio of a DOM element
+
+## Examples
+
+### Default usage
+
+<code src="./demo/demo1.tsx" />
+
+### Pass in DOM element
+
+<code src="./demo/demo2.tsx" />
+
+
+## API
+
+```ts
+const visibleRatio = useVisibleRatio(target);
+```
+
+### Params
+
+| Property | Description                                                        | Type                   | Default |
+|---------|----------------------------------------------|------------------------|--------|
+| target | DOM element or Ref Object | HTMLElement \| (() => HTMLElement) \| React.MutableRefObject | - |
+
+### Result
+
+| Property | Description                                         | Type  |
+|----------|------------------------------------------|------------|
+| visibleRatio  | Returns a visible part ratio value of a DOM element | number    |

--- a/packages/hooks/src/useVisibleRatio/index.ts
+++ b/packages/hooks/src/useVisibleRatio/index.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import 'intersection-observer';
+
+import { getTargetElement, BasicTarget } from '../utils/dom';
+
+type VisibleRatio = number | undefined;
+
+function useVisibleRatio(target: BasicTarget): VisibleRatio {
+  const [visibleHeightRatio, updateVisibleHeightRatio] = useState<number>(0);
+
+  // set threshold's length with 100
+  const steps = [...new Array(100).keys()].map((num: number) => num / 100);
+
+  useEffect(() => {
+    const el = getTargetElement(target);
+    if (!el) {
+      return () => {};
+    }
+
+    const observer = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            updateVisibleHeightRatio(Number(entry.intersectionRatio.toFixed(2)));
+          } else {
+            updateVisibleHeightRatio(0);
+          }
+        }
+      },
+      {
+        threshold: steps,
+      },
+    );
+
+    observer.observe(el as HTMLElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [typeof target === 'function' ? undefined : target]);
+
+  return visibleHeightRatio;
+}
+
+export default useVisibleRatio;

--- a/packages/hooks/src/useVisibleRatio/index.zh-CN.md
+++ b/packages/hooks/src/useVisibleRatio/index.zh-CN.md
@@ -1,0 +1,42 @@
+---
+title: useVisibleRatio
+nav:
+  title: Hooks
+  path: /hooks
+group:
+  title: Dom
+  path: /dom
+legacy: /zh-CN/dom/use-visible-ratio
+---
+
+# useVisibleRatio
+
+一个用于显示 dom 元素可见区域占元素高度比例/百分比的 Hook
+
+## 代码演示
+
+### 基本用法
+
+<code src="./demo/demo1.tsx" />
+
+### 传入 DOM 元素
+
+<code src="./demo/demo2.tsx" />
+
+## API
+
+```ts
+const visibleRatio = useVisibleRatio(target);
+```
+
+### 参数
+
+| 参数    | 说明                                         | 类型                   | 默认值 |
+|---------|----------------------------------------------|------------------------|--------|
+| target | DOM element or Ref Object | HTMLElement \| (() => HTMLElement) \| React.MutableRefObject |   - |
+
+### 结果
+
+| 参数     | 说明                                     | 类型       |
+|----------|------------------------------------------|------------|
+| visibleRatio  | dom 元素可见区域占元素高度比例/百分比（两位小数）| number    |


### PR DESCRIPTION
增加 `useVisibleRatio` hooks 返回可视区域高度占元素高度百分比/比例

相关：https://github.com/alibaba/hooks/issues/409