### PR TITLE
fix: change fetchProxy to get msg if error

### DIFF
--- a/packages/use-request/src/index.ts
+++ b/packages/use-request/src/index.ts
@@ -68,14 +68,20 @@ function useRequest(service: any, options: any = {}) {
   paginatedRef.current = paginated;
   loadMoreRef.current = loadMore;
 
-  // @ts-ignore
   const fetchProxy = (...args: any[]) =>
     // @ts-ignore
-    fetch(...args).then((res: Response) => {
-      if (res.ok) {
-        return res.json();
-      }
-      throw new Error(res.statusText);
+    fetch(...args).then(async (response: Response) => {
+      return response.json().then((res) => {
+        if (response.ok) {
+          return res;
+        } else {
+          const error = Object.assign({}, res, {
+            status: response.status,
+            statusText: response.statusText,
+          });
+          return Promise.reject(error);
+        }
+      });
     });
 
   const finalRequestMethod = requestMethod || fetchProxy;
@@ -101,7 +107,7 @@ function useRequest(service: any, options: any = {}) {
                 break;
               case 'object':
                 const { url, ...rest } = s;
-                fn = requestMethod ? requestMethod(s) : fetchProxy(url, rest)
+                fn = requestMethod ? requestMethod(s) : fetchProxy(url, rest);
                 break;
             }
           }


### PR DESCRIPTION
在之前的实现中，如果http状态码为400时会直接抛错，用户拿不到后端返回的msg信息，一些依赖后端校验的场景是需要拿到校验信息反馈给用户的。
修改之后的fetchProxy，出现400等非200状态码时，可以正常拿到后端返回的信息。