### PR TITLE
changed to noreset next css

### DIFF
--- a/.umirc.js
+++ b/.umirc.js
@@ -38,7 +38,7 @@ export default {
   links: [
     {
       rel: 'stylesheet',
-      href: 'https://unpkg.com/@alifd/theme-design-pro@0.6.2/dist/next.min.css',
+      href: 'https://unpkg.com/@alifd/theme-design-pro@0.6.2/dist/next-noreset.min.css',
     },
     { rel: 'stylesheet', href: '/style.css' },
   ],


### PR DESCRIPTION
有了 reset 的话，一些样式会被覆盖，比如你会发现

```md
1. test
2. test2
```

没有了 list-style 了