### PR TITLE
`setState` is unnecessary in deps

### DIFF
--- a/packages/hooks/src/useToggle/index.ts
+++ b/packages/hooks/src/useToggle/index.ts
@@ -46,7 +46,7 @@ function useToggle<D extends IState = IState, R extends IState = IState>(
       setLeft,
       setRight,
     };
-  }, [setState]);
+  }, []);
 
   return [state, actions];
 }


### PR DESCRIPTION
Because [here](https://reactjs.org/docs/hooks-reference.html#usestate).
> React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list.

![image](https://user-images.githubusercontent.com/35673748/91630623-5cbf5300-ea05-11ea-9adf-929dcfc47f6e.png)
