### PR TITLE
fix import

### DIFF
--- a/packages/hooks/src/useDebounceEffect/demo/demo1.tsx
+++ b/packages/hooks/src/useDebounceEffect/demo/demo1.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useDebounceEffect from '..';
+import useDebounceEffect from '../';
 
 export default () => {
   const [value, setValue] = useState('hello');

--- a/packages/hooks/src/useDebounceFn/index.ts
+++ b/packages/hooks/src/useDebounceFn/index.ts
@@ -1,6 +1,6 @@
 import debounce from 'lodash.debounce';
 import { useRef } from 'react';
-import { useCreation } from '..';
+import { useCreation } from '../';
 import { DebounceOptions } from '../useDebounce/debounceOptions';
 
 type Fn = (...args: any) => any;

--- a/packages/hooks/src/usePersistFn/__tests__/index.test.ts
+++ b/packages/hooks/src/usePersistFn/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, RenderHookResult } from '@testing-library/react-hooks';
 import { useState } from 'react';
-import usePersistFn from '..';
+import usePersistFn from '../';
 
 // 函数变化，但是地址不变
 

--- a/packages/hooks/src/usePrevious/__tests__/index.test.ts
+++ b/packages/hooks/src/usePrevious/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import usePrevious, { compareFunction as comFunc } from '..';
+import usePrevious, { compareFunction as comFunc } from '../';
 
 describe('usePrevious', () => {
   it('should be defined', () => {

--- a/packages/hooks/src/useResponsive/__tests__/index.test.ts
+++ b/packages/hooks/src/useResponsive/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { useResponsive } from '..';
+import { useResponsive } from '../';
 
 describe('useResponsive', () => {
   function changeWidth(width: number) {

--- a/packages/hooks/src/useThrottleEffect/demo/demo1.tsx
+++ b/packages/hooks/src/useThrottleEffect/demo/demo1.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useThrottleEffect from '..';
+import useThrottleEffect from '../';
 
 export default () => {
   const [value, setValue] = useState('hello');

--- a/packages/hooks/src/useThrottleFn/index.ts
+++ b/packages/hooks/src/useThrottleFn/index.ts
@@ -1,6 +1,6 @@
 import throttle from 'lodash.throttle';
 import { useRef } from 'react';
-import { useCreation } from '..';
+import { useCreation } from '../';
 import { ThrottleOptions } from '../useThrottle/throttleOptions';
 
 type Fn = (...args: any) => any;


### PR DESCRIPTION
由于我们在工程中使用[babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver)配置自定义root及alias，webpack在解析import '..'语法时出现了问题，导致此类用法并未指向`'../'`而是等效于` '自定义root/../'`，应该更规范使用`import '../'`