### PR TITLE
Feat/use history travel

### DIFF
--- a/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
+++ b/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
@@ -199,4 +199,21 @@ describe('useHistoryTravel', () => {
     expect(hook.result.current.backLength).toEqual(0);
     expect(hook.result.current.forwardLength).toEqual(0);
   });
+
+  it('setTemp value should not to record', () => {
+    const hook = renderHook(() => useHistoryTravel('init'));
+    act(() => {
+      hook.result.current.setTemp('temp');
+    });
+    expect(hook.result.current.value).toEqual('temp');
+    act(() => {
+      hook.result.current.setValue('abc');
+    });
+    expect(hook.result.current.value).toEqual('abc');
+    expect(undefHook.result.current.backLength).toEqual(1);
+    act(() => {
+      hook.result.current.go(-1);
+    });
+    expect(hook.result.current.value).toEqual('init');
+  });
 });

--- a/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
+++ b/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
@@ -210,7 +210,7 @@ describe('useHistoryTravel', () => {
       hook.result.current.setValue('abc');
     });
     expect(hook.result.current.value).toEqual('abc');
-    expect(hook.result.current.backLength).toEqual(1);
+    expect(undefHook.result.current.backLength).toEqual(1);
     act(() => {
       hook.result.current.go(-1);
     });

--- a/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
+++ b/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
@@ -210,7 +210,7 @@ describe('useHistoryTravel', () => {
       hook.result.current.setValue('abc');
     });
     expect(hook.result.current.value).toEqual('abc');
-    expect(undefHook.result.current.backLength).toEqual(1);
+    expect(hook.result.current.backLength).toEqual(1);
     act(() => {
       hook.result.current.go(-1);
     });

--- a/packages/hooks/src/useHistoryTravel/index.ts
+++ b/packages/hooks/src/useHistoryTravel/index.ts
@@ -70,9 +70,9 @@ export default function useHistoryTravel<T>(initialValue?: T) {
     (val: T) => {
       setHistory({
         present: present,
-        future: [],
-        past: [...past, present],
-        temp: val
+        future: future,
+        past: past,
+        temp: val,
       });
     },
     [history, setHistory]

--- a/packages/hooks/src/useHistoryTravel/index.ts
+++ b/packages/hooks/src/useHistoryTravel/index.ts
@@ -4,6 +4,7 @@ interface IData<T> {
   present?: T;
   past: T[];
   future: T[];
+  temp?: T
 }
 
 const dumpIndex = <T>(step: number, arr: T[]) => {
@@ -36,7 +37,7 @@ export default function useHistoryTravel<T>(initialValue?: T) {
     future: []
   });
 
-  const { present, past, future } = history;
+  const { present, past, future, temp } = history;
 
   const initialValueRef = useRef(initialValue);
 
@@ -60,6 +61,18 @@ export default function useHistoryTravel<T>(initialValue?: T) {
         present: val,
         future: [],
         past: [...past, present]
+      });
+    },
+    [history, setHistory]
+  );
+
+  const updateTemp = useCallback(
+    (val: T) => {
+      setHistory({
+        present: present,
+        future: [],
+        past: [...past, present],
+        temp: val
       });
     },
     [history, setHistory]
@@ -111,8 +124,9 @@ export default function useHistoryTravel<T>(initialValue?: T) {
   );
 
   return {
-    value: present,
+    value: temp || present,
     setValue: updateValue,
+    setTemp: updateTemp,
     backLength: past.length,
     forwardLength: future.length,
     go,


### PR DESCRIPTION
使用场景：可视化编辑页面需要记录用户操作，支持redo和undo等功能，拖动组件时需显示组件位置数据，但并不需要记录位移时的数据，所以需要一个不记录历史的方法