### PR TITLE
docs: useUrlState csb demo

### DIFF
--- a/packages/use-url-state/index.en-US.md
+++ b/packages/use-url-state/index.en-US.md
@@ -33,13 +33,17 @@ import useUrlState from '@ahooksjs/use-url-state';
 
 ## Examples
 
+### Codesandbox link
+
+https://codesandbox.io/s/suspicious-feather-cz4e0?file=/App.tsx
+
 ### Default usage
 
-<code src="./demo/demo1.tsx" />
+<code src="./demo/demo1.tsx" hideActions='["CSB"]' />
 
 ### Multi-state management
 
-<code src="./demo/demo2.tsx" />
+<code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
 ## API
 

--- a/packages/use-url-state/index.zh-CN.md
+++ b/packages/use-url-state/index.zh-CN.md
@@ -32,13 +32,17 @@ import useUrlState from '@ahooksjs/use-url-state';
 
 ## 代码演示
 
+### Codesandbox 链接
+
+https://codesandbox.io/s/suspicious-feather-cz4e0?file=/App.tsx
+
 ### 默认用法
 
-<code src="./demo/demo1.tsx" />
+<code src="./demo/demo1.tsx" hideActions='["CSB"]' />
 
 ### 多状态管理
 
-<code src="./demo/demo2.tsx" />
+<code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
 ## API
 


### PR DESCRIPTION
close #693 
因为 csb 里需要加 react router 的 provider，但是 dumi 的文档里不需要，所以单独写了 csb 的 demo 附上了链接