### PR TITLE
useInViewport 方法，增加区分未获取到dom元素时候的状态。

### DIFF
--- a/packages/hooks/src/useInViewport/index.ts
+++ b/packages/hooks/src/useInViewport/index.ts
@@ -4,7 +4,7 @@ import { getTargetElement, BasicTarget } from '../utils/dom';
 
 type InViewport = boolean | undefined;
 
-function isInViewPort(el: HTMLElement): boolean | undefined  {
+function isInViewPort(el: HTMLElement): InViewport  {
   if (!el) {
     return undefined;
   }

--- a/packages/hooks/src/useInViewport/index.ts
+++ b/packages/hooks/src/useInViewport/index.ts
@@ -4,7 +4,7 @@ import { getTargetElement, BasicTarget } from '../utils/dom';
 
 type InViewport = boolean | undefined;
 
-function isInViewPort(el: HTMLElement): boolean {
+function isInViewPort(el: HTMLElement): boolean | undefined  {
   if (!el) {
     return undefined;
   }

--- a/packages/hooks/src/useInViewport/index.ts
+++ b/packages/hooks/src/useInViewport/index.ts
@@ -6,7 +6,7 @@ type InViewport = boolean | undefined;
 
 function isInViewPort(el: HTMLElement): boolean {
   if (!el) {
-    return false;
+    return undefined;
   }
 
   const viewPortWidth =


### PR DESCRIPTION
https://codesandbox.io/s/jichuyongfa-forked-8kjhb?file=/App.tsx:168-194
看下控制台的打印 第一个log：false （因为dom是undefinde），第二个 log：true 是真实检测结果，这会导致 页面上的元素因为判断这个值增加类似 fixed css 数据导致闪屏，所以需要一个值来区分是否因为 dom 为获取到导致的 fasle 返回值。所以更改 未获取到dom 时返回 undefinde 更合适。 
```
  const inViewPort = useInViewport(ref);
  const inView = inViewPort === undefined ? true : inViewPort;
```

或者可以尝试增加默认值的方法。