### PR TITLE
fix: useReactive

### DIFF
--- a/packages/hooks/src/useReactive/index.ts
+++ b/packages/hooks/src/useReactive/index.ts
@@ -14,7 +14,7 @@ function observer<T extends object>(initialVal: T, cb: () => void) {
   const proxy = new Proxy<T>(initialVal, {
     get(target, key, receiver) {
       const res = Reflect.get(target, key, receiver);
-      return typeof (res === 'object' && res !== null) ? observer(res, cb) : Reflect.get(target, key);
+      return (typeof res === 'object' && res !== null) ? observer(res, cb) : Reflect.get(target, key);
     },
     set(target, key, val) {
       const ret = Reflect.set(target, key, val);

--- a/packages/hooks/src/useReactive/index.ts
+++ b/packages/hooks/src/useReactive/index.ts
@@ -14,7 +14,7 @@ function observer<T extends object>(initialVal: T, cb: () => void) {
   const proxy = new Proxy<T>(initialVal, {
     get(target, key, receiver) {
       const res = Reflect.get(target, key, receiver);
-      return typeof res === 'object' ? observer(res, cb) : Reflect.get(target, key);
+      return typeof (res === 'object' && res !== null) ? observer(res, cb) : Reflect.get(target, key);
     },
     set(target, key, val) {
       const ret = Reflect.set(target, key, val);


### PR DESCRIPTION
修复当把对象中的属性赋值为null时， 报 Cannot create proxy with a non-object as target or handler