### PR TITLE
Promise rejection is not required when throwOnError is false

### DIFF
--- a/packages/use-request/src/useAsync.ts
+++ b/packages/use-request/src/useAsync.ts
@@ -168,10 +168,6 @@ class Fetch<R, P extends any[]> {
             throw error;
           }
           console.error(error);
-          // eslint-disable-next-line prefer-promise-reject-errors
-          return Promise.reject(
-            'useRequest has caught the exception, if you need to handle the exception yourself, you can set options.throwOnError to true.',
-          );
         }
       })
       .finally(() => {


### PR DESCRIPTION
When Request interceptors are used to handle the errors, the promise rejection leads to `unhandled promise` errors, despite setting `throwOnError: false`. 

If some one needs to throw errors, they can always use `throwOnError: true`.  When `throwOnError` is set as `false` unhandled promise` errors should not happen.

This fix makes this hook work correctly with umi request plugin.

For more details, https://github.com/alibaba/hooks/issues/812