### PR TITLE
fix(useExternal): add an attribute (option.type) to specify the type of external resource

### DIFF
--- a/packages/hooks/src/useExternal/demo/demo1.tsx
+++ b/packages/hooks/src/useExternal/demo/demo1.tsx
@@ -20,12 +20,16 @@ export default () => {
         Status: <b>{status}</b>
       </p>
       <p>
-        Response: <i>{status === 'ready' ? TEST_SCRIPT.start() : '-'}</i>
+        Response: <i>{status === 'ready' ? TEST_SCRIPT?.start() : '-'}</i>
       </p>
       <button type="button" style={{ marginRight: 8 }} onClick={() => toggle()}>
         toggle
       </button>
-      <button type="button" style={{ marginRight: 8 }} onClick={() => unload()}>
+      <button type="button" style={{ marginRight: 8 }} onClick={() => { 
+        unload();
+        // Maybe you wanna remove the global variables or functions after run unload()
+        TEST_SCRIPT = undefined;
+      }}>
         unload
       </button>
       <button type="button" style={{ marginRight: 8 }} onClick={() => load()}>

--- a/packages/hooks/src/useExternal/demo/demo4.tsx
+++ b/packages/hooks/src/useExternal/demo/demo4.tsx
@@ -15,7 +15,8 @@ export default () => {
   const [path, setPath] = React.useState('https://picsum.photos/200/100');
 
   const [status] = useExternal(path, {
-    target: ref,
+    type: 'img',
+    target: ref
   });
 
   return (

--- a/packages/hooks/src/useExternal/index.en-US.md
+++ b/packages/hooks/src/useExternal/index.en-US.md
@@ -55,6 +55,7 @@ const [status, { toggle, unload, load }] = useExternal(path: string, options?: O
 
 | Params     | Description                                  | Type     | Default |
 |------------|----------------------------------------------|----------|---------|
+| type | The type of extarnal resources which need to load, support `js`/`css`/`img`  | `string` | -      |
 | async | The async properties of extarnal resources `<script>` | `boolean` | true       |
 | media | The media properties of extarnal resources `<link>`, support `all`/`screen`/`print`/`handheld` | `string` | all       |
 | target | The DOM or Refs of container which need to load the `<img>` | `HTMLElement` \| `(() => HTMLElement)` \| `MutableRefObject` | -      |

--- a/packages/hooks/src/useExternal/index.zh-CN.md
+++ b/packages/hooks/src/useExternal/index.zh-CN.md
@@ -55,6 +55,7 @@ const [status, { toggle, unload, load }] = useExternal(path: string, options?: O
 
 | 参数     | 说明                                  | 类型     | 默认值 |
 |------------|----------------------------------------------|----------|---------|
+| type | 需引入外部资源的类型，支持 `js`/`css`/`img`  | `string` | -      |
 | async | 引入外链脚本的 `<script>` 的 async 属性 | `boolean` | true       |
 | media | 引入外链样式表 `<link>` 的 media 属性, 如 `all`/`screen`/`print`/`handheld` | `string` | all       |
 | target | 需插入外部图片资源 `<img>` 的父容器 DOM 节点或者 Refs  | `HTMLElement` \| `(() => HTMLElement)` \| `MutableRefObject` | -      |

--- a/public/useExternal/test-external-script.js
+++ b/public/useExternal/test-external-script.js
@@ -1,5 +1,5 @@
-var TEST_SCRIPT = {
-  start: () => {
+window.TEST_SCRIPT = {
+  start: function () {
     return 'Hello World';
   },
 };

--- a/public/useExternal/test-external-script.js
+++ b/public/useExternal/test-external-script.js
@@ -1,4 +1,4 @@
-const TEST_SCRIPT = {
+var TEST_SCRIPT = {
   start: () => {
     return 'Hello World';
   },


### PR DESCRIPTION
## Fix #819

```js
const [status, { toggle, unload, load }] = useExternal(path: string, options?: Options);
```

新增 `options.type`, 若 useExternal 中的正则表达式无法匹配上外部资源，则需用户自行指定外部资源类型。

目前支持 `js` `css` `img` 三种外部资源。

### Options

| 参数     | 说明                                  | 类型     | 默认值 |
|------------|----------------------------------------------|----------|---------|
| type | 需引入外部资源的类型，支持 `js`/`css`/`img`  | `string` | -      |
| async | 引入外链脚本的 `<script>` 的 async 属性 | `boolean` | true       |
| media | 引入外链样式表 `<link>` 的 media 属性, 如 `all`/`screen`/`print`/`handheld` | `string` | all       |
| target | 需插入外部图片资源 `<img>` 的父容器 DOM 节点或者 Refs  | `HTMLElement` \| `(() => HTMLElement)` \| `MutableRefObject` | -      |



