### PR TITLE
fix(useDocumentVisibility): default visibility to true for SSR

### DIFF
--- a/packages/hooks/src/useDocumentVisibility/index.ts
+++ b/packages/hooks/src/useDocumentVisibility/index.ts
@@ -4,7 +4,8 @@ import useEventListener from '../useEventListener';
 type VisibilityState = 'hidden' | 'visible' | 'prerender' | undefined;
 
 const getVisibility = () => {
-  if (typeof document === 'undefined') return;
+  // Default document visibility to true for SSR
+  if (typeof document === 'undefined') return true;
   return document.visibilityState;
 };
 


### PR DESCRIPTION
Default document visibility to true for SSR. #854 

``` diff
import { useState } from 'react';
import useEventListener from '../useEventListener';

type VisibilityState = 'hidden' | 'visible' | 'prerender' | undefined;

const getVisibility = () => {
- if (typeof document === 'undefined') return;
+ if (typeof document === 'undefined') return true;
+ // Default document visibility to true for SSR
  return document.visibilityState;
};

function useDocumentVisibility(): VisibilityState {
  const [documentVisibility, setDocumentVisibility] = useState(() => getVisibility());

  useEventListener(
    'visibilitychange',
    () => {
      setDocumentVisibility(getVisibility());
    },
    {
      target: document,
    },
  );

  return documentVisibility;
}

export default useDocumentVisibility;
```