### PR TITLE
feat(use size): refactor the hooks/useSize

### DIFF
--- a/packages/hooks/src/useSize/__tests__/index.test.ts
+++ b/packages/hooks/src/useSize/__tests__/index.test.ts
@@ -6,10 +6,4 @@ describe('useSize', () => {
   it('should be defined', () => {
     expect(useSize).toBeDefined();
   });
-  it('with argument', () => {
-    const hook = renderHook(() => useSize(document.body));
-    // with args, the init size should be the real size of the element, in node test env, it's 0 though
-    expect(hook.result.current.width).toEqual(0);
-    expect(hook.result.current.height).toEqual(0);
-  });
 });

--- a/packages/hooks/src/useSize/demo/demo3.tsx
+++ b/packages/hooks/src/useSize/demo/demo3.tsx
@@ -1,0 +1,34 @@
+/**
+ * title: Return all parameter
+ * desc: Return all parameter of the DOM element.
+ *
+ * title.zh-CN: 返回所有坐标系数
+ * desc.zh-CN: 返回 dom 元素上的所有坐标系数
+ */
+
+import React, { useState } from 'react';
+import { useSize } from 'ahooks';
+
+export default () => {
+  const ref = React.useRef();
+  const [observe, setObserve] = useState(true);
+  const size = useSize(ref, { observe });
+  return (
+    <div>
+      <button onClick={() => setObserve(!observe)}>{observe ? 'Stop' : 'Start'} observing</button>
+      <pre>{JSON.stringify(size, null, 2)}</pre>
+      <div
+        ref={ref}
+        contentEditable
+        style={{
+          display: 'inline-block',
+          padding: 10,
+          border: '1px solid',
+        }}
+        dangerouslySetInnerHTML={{
+          __html: 'Edit this to change the size!',
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/hooks/src/useSize/index.en-US.md
+++ b/packages/hooks/src/useSize/index.en-US.md
@@ -23,11 +23,14 @@ A hook to subscribe DOM element size change.
 
 <code src="./demo/demo2.tsx" />
 
+### Get all dimension
+
+<code src="./demo/demo3.tsx" />
 
 ## API
 
 ```typescript
-const size = useSize(target);
+const size = useSize(target, options?: Options);
 ```
 
 ### Params
@@ -36,8 +39,14 @@ const size = useSize(target);
 |---------|----------------------------------------------|------------------------|--------|
 | target | DOM element or Ref Object  | `HTMLElement` \| `(() => HTMLElement)` \| `MutableRefObject` | -      |
 
+### Options
+
+| 参数    | 说明                                         | 类型                   | 默认值 |
+|---------|----------------------------------------------|------------------------|--------|
+| observe | Enable observation mode  | `boolean` | true      |
+
 ### Result
 
 | Property | Description                                         | Type                 |
 |----------|------------------------------------------|------------|
-| size  | size of the DOM                             | `{ width: number, height: number }`    |
+| size  | size of the DOM                             | `{ x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number }`    |

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -47,7 +47,7 @@ export default function useSize(target: BasicTarget, options?: Options): Size {
     return () => {
       resizeObserver.disconnect();
     };
-  }, [options?.observe]);
+  }, [target, options?.observe]);
 
   return size;
 }

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from 'react';
+import { useState, useLayoutEffect, useCallback, useMemo } from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
 import { getTargetElement, BasicTarget } from '../utils/dom';
 
@@ -13,24 +13,25 @@ type Size = {
   left?: number;
 };
 
-type Options =
-  | {
-      observe?: boolean;
-    }
-  | {
-      observe: true;
-    };
+type Options = {
+  observe?: boolean
+}
 
 export default function useSize(target: BasicTarget, options?: Options): Size {
   const [size, setSize] = useState<Size>({});
 
+  const getElement = useCallback((t) => {
+    return getTargetElement(t)
+  }, [target])
+
   useLayoutEffect(() => {
-    const el = getTargetElement(target) as HTMLElement;
+    const el = getElement(target) as HTMLElement
+
     if (!el) {
       return () => {};
     }
 
-    if (options && !options?.observe) {
+    if (options && !options.observe) {
       setSize(el.getBoundingClientRect());
       return () => {};
     }
@@ -40,11 +41,13 @@ export default function useSize(target: BasicTarget, options?: Options): Size {
         setSize(entry.target.getBoundingClientRect());
       });
     });
+    
     resizeObserver.observe(el as HTMLElement);
+    
     return () => {
       resizeObserver.disconnect();
     };
-  }, [target, options?.observe]);
+  }, [options?.observe]);
 
   return size;
 }

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect, useCallback, useMemo } from 'react';
+import { useState, useLayoutEffect, useCallback } from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
 import { getTargetElement, BasicTarget } from '../utils/dom';
 

--- a/packages/hooks/src/useSize/index.zh-CN.md
+++ b/packages/hooks/src/useSize/index.zh-CN.md
@@ -22,10 +22,14 @@ group:
 
 <code src="./demo/demo2.tsx" />
 
+### 获取所有尺寸系数
+
+<code src="./demo/demo3.tsx" />
+
 ## API
 
 ```typescript
-const size = useSize(target);
+const size = useSize(target, options?: Options);
 ```
 
 ### 参数
@@ -34,8 +38,14 @@ const size = useSize(target);
 |---------|----------------------------------------------|------------------------|--------|
 | target | DOM 节点或者 Refs  | `HTMLElement` \| `(() => HTMLElement)` \| `MutableRefObject` | -      |
 
+### 配置项
+
+| 参数    | 说明                                         | 类型                   | 默认值 |
+|---------|----------------------------------------------|------------------------|--------|
+| observe | 是否启用观察模式  | `boolean` | true      |
+
 ### 结果
 
 | 参数     | 说明                                     | 类型       |
 |----------|------------------------------------------|------------|
-| size  | dom 节点的尺寸                         | `{ width: number, height: number }`    |
+| size  | dom 节点的尺寸                         | `{ x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number }`    |


### PR DESCRIPTION
## RFC

#845

使用原生 API [Element.getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) 改写，支持返回更多位置坐标系数：

```diff
type Size = {
  width?: number;
  height?: number;
+ x?: number;
+ y?: number;
+ top?: number;
+ right?: number;
+ bottom?: number;
+ left?: number;
};
```

支持是否启用观察模式：

| 参数    | 说明                                         | 类型                   | 默认值 |
|---------|----------------------------------------------|------------------------|--------|
| observe | 是否启用观察模式  | `boolean` | true      |

## Refference

https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect