### PR TITLE
fix: focusTimespan首次离开窗口时不等待而立即请求

### DIFF
--- a/packages/use-request/src/utils/limit.ts
+++ b/packages/use-request/src/utils/limit.ts
@@ -3,8 +3,8 @@ export default function limit(fn: any, timespan: number) {
   return (...args: any[]) => {
     if (pending) return;
     pending = true;
-    fn(...args);
     setTimeout(() => {
+      fn(...args);
       pending = false;
     }, timespan);
   };


### PR DESCRIPTION
focusTimespan在首次切换窗口时并不会等待五分钟，多了一个重复请求