### PR TITLE
fix(useReactive): 修复当使用 delete 操作符时页面不刷新

### DIFF
--- a/packages/hooks/src/useReactive/__tests__/index.test.tsx
+++ b/packages/hooks/src/useReactive/__tests__/index.test.tsx
@@ -12,6 +12,7 @@ const Demo = () => {
       },
     },
     arr: [1],
+    foo: 'foo',
   });
 
   return (
@@ -19,9 +20,15 @@ const Demo = () => {
       <p>
         counter state.count：<span role="addCount">{state.count}</span>
       </p>
+      <p>
+        delete property：<span role="deleteProperty">{state.foo}</span>
+      </p>
 
       <button role="addCountBtn" onClick={() => (state.count += 1)}>
         state.count++
+      </button>
+      <button role="deletePropertyBtn" onClick={() => delete state.foo}>
+        delete state.foo
       </button>
       <button role="subCountBtn" style={{ marginLeft: '50px' }} onClick={() => (state.count -= 1)}>
         state.count--
@@ -142,5 +149,18 @@ describe('test useReactive feature', () => {
       fireEvent.change(input, { target: { value: 'bbb' } });
     });
     expect(inputVal.textContent).toBe('bbb');
+  });
+
+  it('delete object property', () => {
+    let wrap = render(<Demo />);
+
+    let deleteProperty = wrap.getByRole('deleteProperty');
+    let deletePropertyBtn = wrap.getByRole('deletePropertyBtn');
+    expect(deleteProperty.textContent).toBe('foo');
+
+    act(() => {
+      fireEvent.click(deletePropertyBtn);
+    });
+    expect(deleteProperty.textContent).toBe('');
   });
 });

--- a/packages/hooks/src/useReactive/index.ts
+++ b/packages/hooks/src/useReactive/index.ts
@@ -35,6 +35,11 @@ function observer<T extends object>(initialVal: T, cb: () => void): T {
       cb();
       return ret;
     },
+    deleteProperty(target, key) {
+      const ret = Reflect.deleteProperty(target, key);
+      cb();
+      return ret;
+    },
   });
 
   proxyMap.set(initialVal, proxy);


### PR DESCRIPTION
**demo**：

```jsx
const App = () => {
const obj =useReactive({ name: 'zhang', age: 10 })
const handleDeleteName = () => {
  delete obj.name
}
return <div>
  <div>name: {obj.name}</div>
  <button onClick={ () => handleDeleteName() }>删除 name</button>
</div>
}
```

**预期结果**：我们需要删除一个属性时，视图应该刷新

**实际结果**：并未发生变化

**解决方案**：使用  `deleteProperty`  拦截 `delete` 操作，具体情况 packages/hooks/src/useReactive/index.ts 38 行
