### PR TITLE
optimize(useUnmount): remove useless deps

### DIFF
--- a/packages/hooks/src/useUnmount/index.ts
+++ b/packages/hooks/src/useUnmount/index.ts
@@ -11,7 +11,7 @@ const useUnmount = (fn: any) => {
         fnPersist();
       }
     },
-    [fnPersist],
+    [],
   );
 };
 


### PR DESCRIPTION
根据`usePersistFn`函数的定义，`fnPersist`的引用地址不会改变，因此将它传入`deps`似乎是多余的

````typescript
const useUnmount = (fn: any) => {
  const fnPersist = usePersistFn(fn);

  useEffect(
    () => () => {
      if (isFunction(fnPersist)) {
        fnPersist();
      }
    },
    [fnPersist],
  );
};
````

至少在`useEffect > updateEffect > updateEffectImpl > areHookInputsEqual`函数中会进行一次比较

````typescript
function areHookInputsEqual(
  nextDeps: Array<mixed>,
  prevDeps: Array<mixed> | null,
) {
  for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
    if (is(nextDeps[i], prevDeps[i])) {
      continue;
    }
    return false;
  }
  return true;
}
````

是因为`'react-hooks/exhaustive-deps': 'warn'`这条规则才加上的吗