### PR TITLE
feat: useUpdateEffect 模拟componentDidUpdate 

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -58,6 +58,7 @@ import useLockFn from './useLockFn';
 import useTrackedEffect from './useTrackedEffect';
 import useUnmountedRef from './useUnmountedRef';
 import useExternal from './useExternal';
+import useDidUpdateEffect from './useDidUpdateEffect';
 
 const useControlledValue: typeof useControllableValue = function (...args: any) {
   console.warn(
@@ -130,4 +131,5 @@ export {
   useLockFn,
   useUnmountedRef,
   useExternal,
+  useDidUpdateEffect,
 };

--- a/packages/hooks/src/useDidUpdateEffect/__test__/index.test.ts
+++ b/packages/hooks/src/useDidUpdateEffect/__test__/index.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useDidUpdateEffect from '../index';
+
+describe('useDidUpdateEffect', () => {
+  it('should be defined', () => {
+    expect(useDidUpdateEffect).toBeDefined();
+  });
+  it('test on mounted', async () => {
+    let mountedState = 1;
+    const hook = renderHook(() =>
+      useDidUpdateEffect(() => {
+        mountedState = 2;
+      }, []),
+    );
+    expect(mountedState).toEqual(1);
+    hook.rerender();
+    expect(mountedState).toEqual(2);
+  });
+  it('test on optional', () => {
+    let mountedState = 1;
+    const hook = renderHook(() =>
+      useDidUpdateEffect(() => {
+        mountedState = 3;
+      }, [mountedState]),
+    );
+    expect(mountedState).toEqual(1);
+    mountedState = 2;
+    hook.rerender();
+    expect(mountedState).toEqual(3);
+  });
+  it('test on prevDeps', () => {
+    let mountedState = 1;
+    let prevDeps;
+    const hook = renderHook(() =>
+      useDidUpdateEffect(
+        prev => {
+          prevDeps = prev;
+          mountedState = 3;
+        },
+        [mountedState],
+      ),
+    );
+    expect(mountedState).toEqual(1);
+    expect(prevDeps).toEqual(undefined);
+    mountedState = 2;
+    hook.rerender();
+    expect(mountedState).toEqual(3);
+    expect(prevDeps).toEqual(2);
+  });
+  it('test on unMount', () => {
+    let mountedState = 1;
+    let prevDeps;
+    const hook = renderHook(() =>
+      useDidUpdateEffect(
+        prev => {
+          prevDeps = prev;
+          mountedState = 3;
+          return () => {
+            mountedState = 4;
+          };
+        },
+        [mountedState],
+      ),
+    );
+    mountedState = 2;
+    hook.rerender();
+    expect(mountedState).toEqual(3);
+    expect(prevDeps).toEqual(2);
+    hook.unmount();
+    expect(mountedState).toEqual(4);
+    expect(prevDeps).toEqual(2);
+  });
+});

--- a/packages/hooks/src/useDidUpdateEffect/demo/demo1.tsx
+++ b/packages/hooks/src/useDidUpdateEffect/demo/demo1.tsx
@@ -1,0 +1,37 @@
+/**
+ * title: Basic usage
+ * desc: This hook is exactly the same as useEffect, except it omits the first render,  only runs when dependencies update, And you can get the previous dependency on the first parameter of effect.
+ *
+ * title.zh-CN: 基础用法
+ * desc.zh-CN: 使用上与 useEffect 完全相同，只是它忽略了首次渲染，只在依赖项更新时运行, 且可以在effect第一个参数上获取上一次的依赖项。
+ */
+
+import React, { useState, DependencyList } from 'react';
+import { useDidUpdateEffect } from 'ahooks';
+
+export default () => {
+  const [count, setCount] = useState<number>(0);
+  const [prevDeps, setPrevDeps] = useState<DependencyList>();
+
+  useDidUpdateEffect(
+    (prevDeps?: DependencyList) => {
+      setPrevDeps(prevDeps);
+      return () => {
+        // do something
+      };
+    },
+    [count],
+  ); // you can include deps array if necessary
+
+  return (
+    <div>
+      <p>prevDeps: {prevDeps ? JSON.stringify(prevDeps) : ''}</p>
+      <p>currentDeps: {count}</p>
+      <p>
+        <button type="button" onClick={() => setCount(c => c + 1)}>
+          reRender
+        </button>
+      </p>
+    </div>
+  );
+};

--- a/packages/hooks/src/useDidUpdateEffect/index.en-US.md
+++ b/packages/hooks/src/useDidUpdateEffect/index.en-US.md
@@ -1,0 +1,36 @@
+---
+title: useDidUpdateEffect
+nav:
+  title: Hooks
+  path: /hooks
+group:
+  title: LifeCycle
+  path: /life-cycle
+---
+
+# useDidUpdateEffect
+
+A hook of useEffect that simulation of ComponentDidUpdate.
+ 
+
+## Examples
+
+### Basic usage
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+useDidUpdateEffect(
+  effect: (prevDeps: deps) => ReturnType<React.EffectCallback>,
+  deps?: deps,
+)
+```
+
+### Params
+
+| Property | Description                                        | Type                                      | Default |
+|----------|----------------------------------------------------|-------------------------------------------|---------|
+| effect   | Executable function                                | `(prevDeps: deps) => ReturnType<React.EffectCallback>` | -       |
+| deps     | Optionally, pass in objects that depend on changes |   `DependencyList` \| `undefined`                 | -       |

--- a/packages/hooks/src/useDidUpdateEffect/index.ts
+++ b/packages/hooks/src/useDidUpdateEffect/index.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, EffectCallback, DependencyList } from 'react';
+
+type Deps = DependencyList;
+
+type useDidUpdateEffect = (
+  effect: (prevDeps: Deps | undefined) => ReturnType<EffectCallback>,
+  deps?: Deps,
+) => void;
+
+const useDidUpdateEffect: useDidUpdateEffect = (effect, deps) => {
+  const isMounted = useRef(false);
+  const prevDeps = useRef(deps);
+
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+    } else {
+      const destructor = effect(prevDeps.current);
+      prevDeps.current = deps;
+      // handle unmount
+      return destructor;
+    }
+  }, deps);
+};
+
+export default useDidUpdateEffect;

--- a/packages/hooks/src/useDidUpdateEffect/index.zh-CN.md
+++ b/packages/hooks/src/useDidUpdateEffect/index.zh-CN.md
@@ -1,0 +1,35 @@
+---
+title: useDidUpdateEffect
+nav:
+  title: Hooks
+  path: /hooks
+group:
+  title: LifeCycle
+  path: /life-cycle
+---
+
+# useDidUpdateEffect
+
+一个模拟 componentDidUpdate 的 useEffect hook。
+
+## 代码演示
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+useDidUpdateEffect(
+  effect: (prevDeps: deps) => ReturnType<React.EffectCallback>,
+  deps?: deps,
+)
+```
+
+### Params
+
+| 参数   | 说明                       | 类型                                                   | 默认值 |
+| ------ | -------------------------- | ------------------------------------------------------ | ------ |
+| effect | 可执行函数                 | `(prevDeps: deps) => ReturnType<React.EffectCallback>` | -      |
+| deps   | 可选项，传入依赖变化的对象 | `DependencyList` \| `undefined`                        | -      |


### PR DESCRIPTION
A hook of useEffect that simulation of ComponentDidUpdate.
一个模拟 componentDidUpdate 的 useEffect hook。
demo:
useDidUpdateEffect((prevDeps) => {
    if(prevDeps[0] && !visibile){
        // do something
    }
    return () => {
      // do something
    };
  },  [visibile]);