### PR TITLE
feat: useScroll添加Option：scrollArea 获得滚动区域宽高

### DIFF
--- a/packages/hooks/src/useScroll/index.en-US.md
+++ b/packages/hooks/src/useScroll/index.en-US.md
@@ -30,7 +30,7 @@ Get the scroll position of an element.
 ## API
 
 ```typescript
-const position = useScroll(target, shouldUpdate);
+const { position, scrollArea } = useScroll(target, shouldUpdate);
 ```
 
 ### Params
@@ -41,8 +41,9 @@ const position = useScroll(target, shouldUpdate);
 | shouldUpdate | controll weather update scroll status | `({ top: number, left: number}) => boolean` | `({ top: number, left: number}) => true` |
 
 
-### Result
+### Options
 
 | Property | Description                                 | Type                          |
 |----------|---------------------------------------------|-------------------------------|
 | position | The current scroll position of the element. | `{left: number, top: number}` |
+| position | The current scroll container width and height. | `{scrollWidth: number, scrollHeight: number}` |

--- a/packages/hooks/src/useScroll/index.ts
+++ b/packages/hooks/src/useScroll/index.ts
@@ -7,13 +7,28 @@ interface Position {
   top: number;
 }
 
+interface ScrollArea {
+  scrollWidth: number;
+  scrollHeight: number;
+}
+
+interface Options {
+  position: Position;
+  scrollArea?: ScrollArea;
+}
+
 export type Target = BasicTarget<HTMLElement | Document>;
 export type ScrollListenController = (val: Position) => boolean;
 
-function useScroll(target?: Target, shouldUpdate: ScrollListenController = () => true): Position {
+function useScroll(target?: Target, shouldUpdate: ScrollListenController = () => true): Options {
   const [position, setPosition] = useState<Position>({
     left: NaN,
     top: NaN,
+  });
+
+  const [scrollArea, setScrollArea] = useState<ScrollArea>({
+    scrollWidth: NaN,
+    scrollHeight: NaN,
   });
 
   const shouldUpdatePersist = usePersistFn(shouldUpdate);
@@ -21,7 +36,21 @@ function useScroll(target?: Target, shouldUpdate: ScrollListenController = () =>
   useEffect(() => {
     const el = getTargetElement(target, document);
     if (!el) return;
+    setScrollArea({
+      scrollWidth:
+        (el as Target) === document
+          ? document.scrollingElement!.scrollWidth
+          : (el as HTMLElement).scrollWidth,
+      scrollHeight:
+        (el as Target) === document
+          ? document.scrollingElement!.scrollHeight
+          : (el as HTMLElement).scrollHeight,
+    });
+  }, [target]);
 
+  useEffect(() => {
+    const el = getTargetElement(target, document);
+    if (!el) return;
     function updatePosition(currentTarget: Target): void {
       let newPosition;
       if (currentTarget === document) {
@@ -51,7 +80,10 @@ function useScroll(target?: Target, shouldUpdate: ScrollListenController = () =>
     };
   }, [target, shouldUpdatePersist]);
 
-  return position;
+  return {
+    position,
+    scrollArea,
+  };
 }
 
 export default useScroll;

--- a/packages/hooks/src/useScroll/index.zh-CN.md
+++ b/packages/hooks/src/useScroll/index.zh-CN.md
@@ -30,7 +30,7 @@ group:
 ## API
 
 ```typescript
-const position = useScroll(target, shouldUpdate);
+const { position, scrollArea } = useScroll(target, shouldUpdate);
 ```
 
 ### Params
@@ -41,8 +41,9 @@ const position = useScroll(target, shouldUpdate);
 | shouldUpdate | 控制是否更新滚动信息  | `({ top: number, left: number}) => boolean` | `({ top: number, left: number}) => true` |
 
 
-### Result
+### Options
 
 | 参数     | 说明                   | 类型                          |
 |----------|------------------------|-------------------------------|
 | position | 滚动容器当前的滚动位置 | `{left: number, top: number}` |
+| scrollArea | 滚动容器宽高 | `{scrollWidth: number, scrollHeight: number}` |


### PR DESCRIPTION
### changelog
添加`Option`：`scrollArea`以便获取滚动区域宽高
```typescript
const { position, scrollArea } = useScroll(target, shouldUpdate);
```
### Options

| 参数     | 说明                   | 类型                          |
|----------|------------------------|-------------------------------|
| position | 滚动容器当前的滚动位置 | `{left: number, top: number}` |
| scrollArea | 滚动容器宽高 | `{scrollWidth: number, scrollHeight: number}` |

可解决`监听一个滚动区域是否触底`等需求