### PR TITLE
fix(useVirtualList): the state is not recalculated when the list changes

### DIFF
--- a/packages/hooks/src/useVirtualList/index.ts
+++ b/packages/hooks/src/useVirtualList/index.ts
@@ -70,7 +70,7 @@ export default <T = any>(list: T[], options: OptionType) => {
 
   useEffect(() => {
     calculateRange();
-  }, [size.width, size.height]);
+  }, [size.width, size.height, list.length]);
 
   const totalHeight = useMemo(() => {
     if (typeof itemHeight === 'number') {


### PR DESCRIPTION
这个监听重新计算的Effect少了list.length的依赖
导致数据变化的时候，不会更新重算state

```ts
  useEffect(() => {
    calculateRange();
  }, [size.width, size.height]);
```