### PR TITLE
types/request service

### DIFF
--- a/packages/use-request/src/types.ts
+++ b/packages/use-request/src/types.ts
@@ -10,6 +10,7 @@ export type Mutate<R> = (x: R | undefined | ((data: R) => R)) => void;
 
 export interface RequestServiceObject extends RequestInit {
   readonly url: string;
+  [key: string]: any; // backward compatibility
 }
 export type RequestService = string | RequestServiceObject;
 export type CombineService<R, P extends any[]> =

--- a/packages/use-request/src/types.ts
+++ b/packages/use-request/src/types.ts
@@ -8,7 +8,10 @@ export type Service<R, P extends any[]> = (...args: P) => Promise<R>;
 export type Subscribe<R, P extends any[]> = (data: FetchResult<R, P>) => void;
 export type Mutate<R> = (x: R | undefined | ((data: R) => R)) => void;
 
-export type RequestService = string | { [key: string]: any };
+export interface RequestServiceObject extends RequestInit {
+  readonly url: string;
+}
+export type RequestService = string | RequestServiceObject;
 export type CombineService<R, P extends any[]> =
   | RequestService
   | ((...args: P) => RequestService)


### PR DESCRIPTION
当使用 use-request 传入 object 时，缺乏类型提示

```js
const { loading, run } = useRequest((username) => ({
  url: '/api/changeUsername',
  method: 'post',
  body: JSON.stringify({ username }),
}))
```

有关 issue - [ice-4417](https://github.com/alibaba/ice/issues/4417)