### PR TITLE
feat(useInterval): use setTimeout instead of setInterval

### DIFF
--- a/packages/hooks/src/useInterval/index.ts
+++ b/packages/hooks/src/useInterval/index.ts
@@ -17,13 +17,18 @@ function useInterval(
     if (immediate) {
       fnRef.current?.();
     }
-    const timer = setInterval(() => {
-      fnRef.current?.();
-    }, delay);
-    return () => {
-      clearInterval(timer);
+    let timer;
+    const run = () => {
+      timer = setTimeout(() => {
+        fnRef.current?.();
+        run();
+      }, delay);
     };
-  }, [delay]);
+    run();
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [delay, immediate]);
 }
 
 export default useInterval;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

### 💡 需求背景和解决方案

在`useInterval`中使用`setTimeout`模拟`setInterval`，避免`setInterval`的潜在问题。

| 语言    | 更新描述                                                |
| ------- | ------------------------------------------------------- |
| 🇺🇸 英文 | Use setTimeout to mock setInterval in useInterval hook. |
| 🇨🇳 中文 | 在useInterval hook中使用setTimeout来模拟setInterval。   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供