### PR TITLE
fix(useRequest): fix double request when paginated or loadMore mode

### DIFF
--- a/packages/use-request/src/useAsync.ts
+++ b/packages/use-request/src/useAsync.ts
@@ -282,6 +282,9 @@ function useAsync<R, P extends any[], U, UU extends U = any>(
     pollingInterval = 0,
     pollingWhenHidden = true,
 
+    paginated,
+    loadMore,
+
     defaultParams = [],
     refreshOnWindowFocus = false,
     focusTimespan = 5000,
@@ -413,7 +416,7 @@ function useAsync<R, P extends any[], U, UU extends U = any>(
   // for ready
   const hasTriggeredByReady = useRef(false);
   useUpdateEffect(() => {
-    if (ready) {
+    if (ready && !paginated && !loadMore) {
       if (!hasTriggeredByReady.current && readyMemoryParams.current) {
         runRef.current(...readyMemoryParams.current);
       }
@@ -423,7 +426,7 @@ function useAsync<R, P extends any[], U, UU extends U = any>(
 
   // 第一次默认执行
   useEffect(() => {
-    if (!manual) {
+    if (!manual && !paginated && !loadMore) {
       // 如果有缓存，则重新请求
       if (Object.keys(fetches).length > 0) {
         // 如果 staleTime 是 -1，则 cache 永不过期

--- a/packages/use-request/src/useLoadMore.ts
+++ b/packages/use-request/src/useLoadMore.ts
@@ -33,6 +33,7 @@ function useLoadMore<R extends LoadMoreFormatReturn, RR = any>(
 
   const result: any = useAsync(service, {
     ...(restOptions as any),
+    refreshDeps,
     fetchKey: (d) => d?.list?.length || 0,
     onSuccess: (...params) => {
       setLoadingMore(false);

--- a/packages/use-request/src/usePaginated.ts
+++ b/packages/use-request/src/usePaginated.ts
@@ -38,10 +38,16 @@ function usePaginated<R, Item, U extends Item = any>(
       },
     ],
     ...(restOptions as any),
+    paginated,
+    refreshDeps,
   });
 
-  const { current = 1, pageSize = defaultPageSize, sorter = {}, filters = {} } =
-    params && params[0] ? params[0] : ({} as any);
+  const {
+    current = 1,
+    pageSize = defaultPageSize,
+    sorter = {},
+    filters = {},
+  } = params && params[0] ? params[0] : ({} as any);
 
   // 只改变 pagination，其他参数原样传递
   const runChangePaination = useCallback(


### PR DESCRIPTION
reference:  https://github.com/alibaba/hooks/issues/816  
当设置了paginated/loadMore时候，可以忽略ready变化调用的side effect。   
