### PR TITLE
feat: add useGetState

### DIFF
--- a/config/hooks.ts
+++ b/config/hooks.ts
@@ -53,6 +53,7 @@ export const menus = [
       'usePrevious',
       'useRafState',
       'useSafeState',
+      'useGetState',
     ],
   },
   {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -67,6 +67,7 @@ import useUpdateLayoutEffect from './useUpdateLayoutEffect';
 import useVirtualList from './useVirtualList';
 import useWebSocket from './useWebSocket';
 import useWhyDidYouUpdate from './useWhyDidYouUpdate';
+import useGetState from './useGetState';
 
 export {
   useRequest,
@@ -139,4 +140,5 @@ export {
   useAntdTable,
   useFusionTable,
   useInfiniteScroll,
+  useGetState,
 };

--- a/packages/hooks/src/useGetState/__tests__/index.test.ts
+++ b/packages/hooks/src/useGetState/__tests__/index.test.ts
@@ -1,0 +1,40 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useGetState from '../index';
+
+describe('useGetState', () => {
+  it('should be defined', () => {
+    expect(useGetState).toBeDefined();
+  });
+
+  const setUp = <T>(initialValue: T) =>
+    renderHook(() => {
+      const [state, setState, getState] = useGetState<T>(initialValue);
+      return {
+        state,
+        setState,
+        getState,
+      } as const;
+    });
+
+  it('should support initialValue', () => {
+    const hook = setUp(() => 0);
+    expect(hook.result.current.state).toEqual(0);
+  });
+
+  it('should support update', () => {
+    const hook = setUp(0);
+    act(() => {
+      hook.result.current.setState(1);
+    });
+    expect(hook.result.current.getState()).toEqual(1);
+  });
+
+  it('should getState frozen', () => {
+    const hook = setUp(0);
+    const prevGetState = hook.result.current.getState;
+    act(() => {
+      hook.result.current.setState(1);
+    });
+    expect(hook.result.current.getState).toEqual(prevGetState);
+  });
+});

--- a/packages/hooks/src/useGetState/demo/demo1.tsx
+++ b/packages/hooks/src/useGetState/demo/demo1.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useGetState } from 'ahooks';
+
+export default () => {
+  const [count, setCount, getCount] = useGetState<number>(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      console.log('interval count', getCount());
+    }, 3000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <button onClick={() => setCount(count => count + 1)}>
+      count: {count}
+    </button>
+  );
+};

--- a/packages/hooks/src/useGetState/index.en-US.md
+++ b/packages/hooks/src/useGetState/index.en-US.md
@@ -1,0 +1,20 @@
+---
+nav:
+  path: /hooks
+---
+
+# ueGetState
+
+with `useRef`, add a getter method to the return value of `React.useState` to get the latest value
+
+## Examples
+
+### Default usage
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+const [state, setState, getState] = ueGetState<S>(initialState: S | (() => S)): [S, (nextState: S | ((prevState: S) => S)) => void, () => S]
+```

--- a/packages/hooks/src/useGetState/index.en-US.md
+++ b/packages/hooks/src/useGetState/index.en-US.md
@@ -5,7 +5,7 @@ nav:
 
 # ueGetState
 
-with `useRef`, add a getter method to the return value of `React.useState` to get the latest value
+Add a getter method to the return value of `React.useState` to get the latest value
 
 ## Examples
 

--- a/packages/hooks/src/useGetState/index.ts
+++ b/packages/hooks/src/useGetState/index.ts
@@ -1,0 +1,15 @@
+import { useState, useRef, useCallback, Dispatch, SetStateAction } from 'react';
+
+type GetState<S> = () => S;
+
+function useGetState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>, GetState<S>] {
+  const [state, setState] = useState<S>(initialState);
+  const stateRef = useRef<S>(state);
+  stateRef.current = state;
+
+  const getState = useCallback<GetState<S>>(() => stateRef.current, []);
+
+  return [state, setState, getState];
+}
+
+export default useGetState;

--- a/packages/hooks/src/useGetState/index.zh-CN.md
+++ b/packages/hooks/src/useGetState/index.zh-CN.md
@@ -1,0 +1,20 @@
+---
+nav:
+  path: /hooks
+---
+
+# useGetState
+
+搭配 useRef，在普通 useState 返回值中增加 getter 方法穿透闭包获取最新值
+
+## 代码演示
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+const [state, setState, getState] = ueGetState<S>(initialState: S | (() => S)): [S, (nextState: S | ((prevState: S) => S)) => void, () => S]
+```

--- a/packages/hooks/src/useGetState/index.zh-CN.md
+++ b/packages/hooks/src/useGetState/index.zh-CN.md
@@ -5,7 +5,7 @@ nav:
 
 # useGetState
 
-搭配 useRef，在普通 useState 返回值中增加 getter 方法穿透闭包获取最新值
+给 `React.useState` 增加了一个 getter 方法，以获取当前最新值。
 
 ## 代码演示
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

#1306

### 💡 需求背景和解决方案

useGetState: 在普通 useState 返回值中增加 getter 方法穿透闭包获取最新值

具体参考上述 issue

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Add a getter method to the return value of `React.useState` to get the latest value  |
| 🇨🇳 中文 |  给 `React.useState` 增加了一个 getter 方法，以获取当前最新值  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 补充文档
- [x] 提供代码演示
- [x] 补充 TypeScript 定义
- [x] 提供 Changelog
