### PR TITLE
fix(useUrlState): setState should emit state update

### DIFF
--- a/packages/use-url-state/src/index.ts
+++ b/packages/use-url-state/src/index.ts
@@ -22,7 +22,7 @@ export default <S extends UrlState = UrlState>(initialState?: S | (() => S), opt
   const location = useLocation();
   const history = useHistory();
 
-  const [, update] = useState(false);
+  const [updateFlag, update] = useState(false);
 
   const initialStateRef = useRef(
     typeof initialState === 'function' ? (initialState as () => S)() : initialState || {},
@@ -37,7 +37,7 @@ export default <S extends UrlState = UrlState>(initialState?: S | (() => S), opt
       ...initialStateRef.current,
       ...queryFromUrl,
     }),
-    [queryFromUrl],
+    [queryFromUrl, updateFlag],
   );
 
   const setState = (s: React.SetStateAction<state>) => {


### PR DESCRIPTION
使用setState更新时，如果前后query并无变化，此时state并不会更新，为了与useState更类似，这里在setState时，不管数据是否有变化，state都应触发改变

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#881 
#888 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
