### PR TITLE
chore: 增加发布 `ahooks@2.x` 的同时自动发布 `ahooks-v2@2.x` 的脚本

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build:doc": "dumi build",
     "pub:doc": "surge ./dist --domain ahooks-v2.surge.sh",
     "pub:doc-gitee": "cd ./dist && rm -rf .git && touch .spa && touch .nojekyll && git init && git remote add origin git@gitee.com:ahooks/ahooks-v2.git && git add -A && git commit -m \"publish docs\" && git push origin master -f && echo https://gitee.com/ahooks/ahooks-v2/pages",
-    "pub": "lerna publish"
+    "pub": "lerna publish && npm run pub-v2",
+    "pub-v2": "node scripts/pub-v2.js"
   },
   "husky": {
     "hooks": {
@@ -66,6 +67,9 @@
     "umi-request": "^1.2.18",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.10",
-    "webpack-merge": "^4.2.2"
+    "webpack-merge": "^4.2.2",
+    "jsonfile": "^6.1.0",
+    "semver": "^7.3.5",
+    "execa": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:doc": "dumi build",
     "pub:doc": "surge ./dist --domain ahooks-v2.surge.sh",
     "pub:doc-gitee": "cd ./dist && rm -rf .git && touch .spa && touch .nojekyll && git init && git remote add origin git@gitee.com:ahooks/ahooks-v2.git && git add -A && git commit -m \"publish docs\" && git push origin master -f && echo https://gitee.com/ahooks/ahooks-v2/pages",
-    "pub": "lerna publish && npm run pub-v2",
+    "pub": "lerna publish && yarn run pub-v2",
     "pub-v2": "node scripts/pub-v2.js"
   },
   "husky": {

--- a/scripts/pub-v2.js
+++ b/scripts/pub-v2.js
@@ -1,0 +1,31 @@
+const jsonfile = require('jsonfile');
+const semver = require('semver');
+const execa = require('execa');
+const path = require('path');
+
+const packageJsonFilePathname = path.resolve(`${__dirname}/../packages/hooks/package.json`);
+const packageDirname = path.dirname(packageJsonFilePathname);
+
+const jsonObj = jsonfile.readFileSync(packageJsonFilePathname);
+const originalName = jsonObj.name;
+const targetName = `${originalName}-v2`;
+
+if (originalName !== 'ahooks') {
+  throw new Error(`"${originalName}" 包名必须是 "ahooks"！`);
+}
+if (!semver.valid(jsonObj.version) || semver.gte(jsonObj.version, '3.0.0') || semver.lt(jsonObj.version, '2.0.0')) {
+  throw new Error(`"${jsonObj.version}" 版本不是合法的 v2 版本！`);
+}
+jsonObj.name = targetName;
+jsonfile.writeFileSync(packageJsonFilePathname, jsonObj, { spaces: 2, finalEOL: true });
+
+try {
+  execa.sync('npm', ['publish'], {
+    cwd: packageDirname,
+    stdio: 'inherit',
+    env: process.env,
+  });
+} finally {
+  jsonObj.name = originalName;
+  jsonfile.writeFileSync(packageJsonFilePathname, jsonObj, { spaces: 2, finalEOL: true });
+}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他改动（自动发布 `ahooks-v2` 的脚本）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

`ahooks-v2` 目前应该是需要手动修改 `package.json` 后手动发布的，我加了个脚本用来发布 `ahooks@2.x` 的同时自动发布 `ahooks-v2@2.x`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇨🇳 中文 |  增加自动发布 `ahooks-v2@2.x`  的脚本 |

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供