### PR TITLE
useVirtualList动态高度时BUG修复

### DIFF
--- a/packages/hooks/src/useVirtualList/index.ts
+++ b/packages/hooks/src/useVirtualList/index.ts
@@ -38,6 +38,9 @@ const useVirtualList = <T = any>(list: T[], options: Options<T>) => {
         endIndex = i;
         break;
       }
+      if (i === list.length - 1) {
+        endIndex = list.length - 1
+      }
     }
     return endIndex - fromIndex;
   };

--- a/packages/hooks/src/useVirtualList/index.ts
+++ b/packages/hooks/src/useVirtualList/index.ts
@@ -34,13 +34,10 @@ const useVirtualList = <T = any>(list: T[], options: Options<T>) => {
     for (let i = fromIndex; i < list.length; i++) {
       const height = itemHeightRef.current(i, list[i]);
       sum += height;
+      endIndex = i;
       if (sum >= containerHeight) {
-        endIndex = i;
-        break;
-      }
-      if (i === list.length - 1) {
-        endIndex = list.length - 1
-      }
+            break;
+       }
     }
     return endIndex - fromIndex;
   };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
useVirtualList在使用函数动态高度时，getVisibleCount没有判断最底部边界的情况，导致获取可视区域元素个数失败

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fixed an error in scrolling when usevirtuallist dynamic height      |
| 🇨🇳 中文 |  修复useVirtualList动态高度时，滚动出现的错误     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供