### PR TITLE
feat: 为useUrlState添加query-string的配置项，用来支持自定义处理数组类型url query的能力

### DIFF
--- a/packages/use-url-state/demo/demo3.tsx
+++ b/packages/use-url-state/demo/demo3.tsx
@@ -1,9 +1,9 @@
 /**
- * title: Array url query
- * desc: Customize the way of parsing and serialization by passing in the configuration of <a href="https://github.com/sindresorhus/query-string#arrayformat">query-string</a>.
+ * title: Custom query-string options
+ * desc: The rules can be customized by passing in parseOptions and stringifyOptions.
  *
- * title.zh-CN: 处理数组类型的url query
- * desc.zh-CN: 可以通过传入<a href="https://github.com/sindresorhus/query-string#arrayformat">query-string</a>的配置来自定义解析和序列化的方式。
+ * title.zh-CN: 自定义 query-string 配置
+ * desc.zh-CN: 可以通过传入 parseOptions 和 stringifyOptions 自定义转换规则。
  */
 
 import React from 'react';
@@ -34,7 +34,7 @@ export default () => {
       >
         变更数组state
       </button>
-      ids: {JSON.stringify(state.ids)}
+      <div>ids: {JSON.stringify(state.ids)}</div>
     </div>
   );
 };

--- a/packages/use-url-state/demo/demo3.tsx
+++ b/packages/use-url-state/demo/demo3.tsx
@@ -1,0 +1,40 @@
+/**
+ * title: Array url query
+ * desc: Customize the way of parsing and serialization by passing in the configuration of <a href="https://github.com/sindresorhus/query-string#arrayformat">query-string</a>.
+ *
+ * title.zh-CN: 处理数组类型的url query
+ * desc.zh-CN: 可以通过传入<a href="https://github.com/sindresorhus/query-string#arrayformat">query-string</a>的配置来自定义解析和序列化的方式。
+ */
+
+import React from 'react';
+import useUrlState from '@ahooksjs/use-url-state';
+
+export default () => {
+  const [state, setState] = useUrlState(
+    { ids: ['1', '2', '3'] },
+    {
+      parseOptions: {
+        arrayFormat: 'comma',
+      },
+      stringifyOptions: {
+        arrayFormat: 'comma',
+      },
+    },
+  );
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          const arr = Array(3)
+            .fill(1)
+            .map(() => Math.floor(Math.random() * 10));
+          setState({ ids: arr });
+        }}
+      >
+        变更数组state
+      </button>
+      ids: {JSON.stringify(state.ids)}
+    </div>
+  );
+};

--- a/packages/use-url-state/src/__tests__/browser.test.tsx
+++ b/packages/use-url-state/src/__tests__/browser.test.tsx
@@ -1,7 +1,7 @@
 import type { RenderHookResult } from '@testing-library/react-hooks';
 import { act, renderHook } from '@testing-library/react-hooks';
 import routeData from 'react-router';
-import useUrlState from '../index';
+import useUrlState, { Options } from '../index';
 
 /* 暂时关闭 act 警告  见：https://github.com/testing-library/react-testing-library/issues/281#issuecomment-480349256 */
 const originalError = console.error;
@@ -18,6 +18,28 @@ beforeAll(() => {
 afterAll(() => {
   console.error = originalError;
 });
+const replaceFn = jest.fn();
+
+function makeMockLocation(search?: string) {
+  const mockLocation = {
+    pathname: '/',
+    hash: '',
+    search: search ? `${search}` : '',
+    state: '',
+  };
+
+  const mockHistory: any = {
+    push: ({ search }) => {
+      replaceFn();
+      mockLocation.search = search;
+    },
+  };
+
+  jest.spyOn(routeData, 'useLocation').mockReturnValue(mockLocation);
+  jest.spyOn(routeData, 'useHistory').mockReturnValue(mockHistory);
+
+  return mockLocation;
+}
 
 describe('useUrlState', () => {
   it('should be defined', () => {
@@ -30,45 +52,27 @@ describe('useUrlState', () => {
       [number, ((s: any) => void) | (() => (s: any) => any)]
     >;
 
-    function setup(key: string, value: string) {
+    function setup(key: string, value: string, config?: Options) {
       hook = renderHook(() => {
-        return useUrlState({ [key]: value });
+        return useUrlState({ [key]: value }, config);
       }) as any;
       hook.rerender();
     }
-
-    const replaceFn = jest.fn();
-
-    const mockLocation = {
-      pathname: '/',
-      hash: '',
-      search: '',
-      state: '',
-    };
-
-    const mockHistory: any = {
-      push: ({ search }) => {
-        replaceFn();
-        mockLocation.search = search;
-      },
-    };
-
-    beforeEach(() => {
-      jest.spyOn(routeData, 'useLocation').mockReturnValue(mockLocation);
-      jest.spyOn(routeData, 'useHistory').mockReturnValue(mockHistory);
-    });
 
     afterEach(() => {
       hook.unmount();
     });
 
     it('history replace should work', async () => {
+      const mockLocation = makeMockLocation();
       act(() => {
         setup('mock', '0');
       });
+
       expect(replaceFn).toBeCalledTimes(0);
       expect(hook.result.current[0]).toEqual({ mock: '0' });
       expect(mockLocation.search).toEqual('');
+
       act(() => {
         hook.result.current[1]({ mock: 1 });
       });
@@ -77,7 +81,33 @@ describe('useUrlState', () => {
       act(() => {
         hook.result.current[1]({ mock: 2, test: 3 });
       });
+
       expect(mockLocation.search).toEqual('mock=2&test=3');
+    });
+
+    it('query-string options should work', async () => {
+      const mockLocation = makeMockLocation();
+
+      act(() => {
+        setup('mock', '0', {
+          parseOptions: {
+            arrayFormat: 'comma',
+          },
+          stringifyOptions: {
+            arrayFormat: 'comma',
+          },
+        });
+      });
+      expect(replaceFn).toBeCalledTimes(0);
+      expect(hook.result.current[0]).toEqual({ mock: '0' });
+      expect(mockLocation.search).toEqual('');
+
+      act(() => {
+        hook.result.current[1]({ mock: 1, test: [1, 2, 3] });
+      });
+      expect(replaceFn).toBeCalledTimes(1);
+      expect(hook.result.current[0]).toEqual({ mock: '1', test: ['1', '2', '3'] });
+      expect(mockLocation.search).toEqual('mock=1&test=1,2,3');
     });
   });
 });

--- a/packages/use-url-state/src/index.ts
+++ b/packages/use-url-state/src/index.ts
@@ -1,8 +1,8 @@
-import { useLatest, useMemoizedFn, useUpdate } from 'ahooks';
-import type { ParseOptions, StringifyOptions } from 'query-string';
+import { useMemoizedFn, useUpdate } from 'ahooks';
 import { parse, stringify } from 'query-string';
-import type * as React from 'react';
+import type { ParseOptions, StringifyOptions } from 'query-string';
 import { useMemo, useRef } from 'react';
+import type * as React from 'react';
 import * as tmp from 'react-router';
 
 // ignore waring `"export 'useNavigate' (imported as 'rc') was not found in 'react-router'`
@@ -33,8 +33,8 @@ const useUrlState = <S extends UrlState = UrlState>(
   type State = Partial<{ [key in keyof S]: any }>;
   const { navigateMode = 'push', parseOptions, stringifyOptions } = options || {};
 
-  const mergedParseOptionsRef = useLatest({ ...baseParseConfig, ...parseOptions });
-  const mergedStringifyOptionsRef = useLatest({ ...baseStringifyConfig, ...stringifyOptions });
+  const mergedParseOptions = { ...baseParseConfig, ...parseOptions };
+  const mergedStringifyOptions = { ...baseStringifyConfig, ...stringifyOptions };
 
   const location = rc.useLocation();
 
@@ -50,7 +50,7 @@ const useUrlState = <S extends UrlState = UrlState>(
   );
 
   const queryFromUrl = useMemo(() => {
-    return parse(location.search, mergedParseOptionsRef.current);
+    return parse(location.search, mergedParseOptions);
   }, [location.search]);
 
   const targetQuery: State = useMemo(
@@ -70,16 +70,14 @@ const useUrlState = <S extends UrlState = UrlState>(
     if (history) {
       history[navigateMode]({
         hash: location.hash,
-        search:
-          stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptionsRef.current) || '?',
+        search: stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptions) || '?',
       });
     }
     if (navigate) {
       navigate(
         {
           hash: location.hash,
-          search:
-            stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptionsRef.current) || '?',
+          search: stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptions) || '?',
         },
         {
           replace: navigateMode === 'replace',

--- a/packages/use-url-state/src/index.ts
+++ b/packages/use-url-state/src/index.ts
@@ -1,9 +1,8 @@
-import { useMemoizedFn, useUpdate } from 'ahooks';
+import { useLatest, useMemoizedFn, useUpdate } from 'ahooks';
+import type { ParseOptions, StringifyOptions } from 'query-string';
 import { parse, stringify } from 'query-string';
-import { useMemo, useRef } from 'react';
-
 import type * as React from 'react';
-
+import { useMemo, useRef } from 'react';
 import * as tmp from 'react-router';
 
 // ignore waring `"export 'useNavigate' (imported as 'rc') was not found in 'react-router'`
@@ -11,13 +10,18 @@ const rc = tmp as any;
 
 export interface Options {
   navigateMode?: 'push' | 'replace';
+  parseOptions?: ParseOptions;
+  stringifyOptions?: StringifyOptions;
 }
 
-const parseConfig = {
-  skipNull: false,
-  skipEmptyString: false,
+const baseParseConfig: ParseOptions = {
   parseNumbers: false,
   parseBooleans: false,
+};
+
+const baseStringifyConfig: StringifyOptions = {
+  skipNull: false,
+  skipEmptyString: false,
 };
 
 type UrlState = Record<string, any>;
@@ -27,7 +31,10 @@ const useUrlState = <S extends UrlState = UrlState>(
   options?: Options,
 ) => {
   type State = Partial<{ [key in keyof S]: any }>;
-  const { navigateMode = 'push' } = options || {};
+  const { navigateMode = 'push', parseOptions, stringifyOptions } = options || {};
+
+  const mergedParseOptionsRef = useLatest({ ...baseParseConfig, ...parseOptions });
+  const mergedStringifyOptionsRef = useLatest({ ...baseStringifyConfig, ...stringifyOptions });
 
   const location = rc.useLocation();
 
@@ -43,7 +50,7 @@ const useUrlState = <S extends UrlState = UrlState>(
   );
 
   const queryFromUrl = useMemo(() => {
-    return parse(location.search, parseConfig);
+    return parse(location.search, mergedParseOptionsRef.current);
   }, [location.search]);
 
   const targetQuery: State = useMemo(
@@ -63,14 +70,16 @@ const useUrlState = <S extends UrlState = UrlState>(
     if (history) {
       history[navigateMode]({
         hash: location.hash,
-        search: stringify({ ...queryFromUrl, ...newQuery }, parseConfig) || '?',
+        search:
+          stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptionsRef.current) || '?',
       });
     }
     if (navigate) {
       navigate(
         {
           hash: location.hash,
-          search: stringify({ ...queryFromUrl, ...newQuery }, parseConfig) || '?',
+          search:
+            stringify({ ...queryFromUrl, ...newQuery }, mergedStringifyOptionsRef.current) || '?',
         },
         {
           replace: navigateMode === 'replace',

--- a/packages/use-url-state/use-url-state.en-US.md
+++ b/packages/use-url-state/use-url-state.en-US.md
@@ -44,6 +44,10 @@ React Router V6：https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 
 <code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
+### Array url query
+
+<code src="./demo/demo3.tsx" hideActions='["CSB"]' />
+
 ## API
 
 ```typescript
@@ -62,6 +66,8 @@ const [state, setState] = useUrlState(initialState, options);
 | Property     | Description                   | Type                  | Default  |
 |--------------|-------------------------------|-----------------------|----------|
 | navigateMode | Type of history navigate mode | `'push' \| 'replace'` | `'push'` |
+| parseOptions | parse options of `query-string` | `ParseOptions` | - |
+| stringifyOptions | stringify options of  `query-string`| `StringifyOptions` | - |
 
 ### Result
 

--- a/packages/use-url-state/use-url-state.en-US.md
+++ b/packages/use-url-state/use-url-state.en-US.md
@@ -44,7 +44,7 @@ React Router V6：https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 
 <code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
-### Array url query
+### Custom query-string options
 
 <code src="./demo/demo3.tsx" hideActions='["CSB"]' />
 
@@ -63,11 +63,11 @@ const [state, setState] = useUrlState(initialState, options);
 
 ### Options
 
-| Property     | Description                   | Type                  | Default  |
-|--------------|-------------------------------|-----------------------|----------|
-| navigateMode | Type of history navigate mode | `'push' \| 'replace'` | `'push'` |
-| parseOptions | parse options of `query-string` | `ParseOptions` | - |
-| stringifyOptions | stringify options of  `query-string`| `StringifyOptions` | - |
+| Property         | Description                                                                                                  | Type                  | Default  |
+|------------------|--------------------------------------------------------------------------------------------------------------|-----------------------|----------|
+| navigateMode     | Type of history navigate mode                                                                                | `'push' \| 'replace'` | `'push'` |
+| parseOptions     | [parse](https://github.com/sindresorhus/query-string#parsestring-options) options of `query-string`          | `ParseOptions`        | -        |
+| stringifyOptions | [stringify](https://github.com/sindresorhus/query-string#stringifyobject-options) options of  `query-string` | `StringifyOptions`    | -        |
 
 ### Result
 

--- a/packages/use-url-state/use-url-state.zh-CN.md
+++ b/packages/use-url-state/use-url-state.zh-CN.md
@@ -43,7 +43,7 @@ React Router V6：https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 
 <code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
-### 处理数组类型的url query
+### 自定义 query-string 配置
 
 <code src="./demo/demo3.tsx" hideActions='["CSB"]' />
 
@@ -62,11 +62,11 @@ const [state, setState] = useUrlState(initialState, options);
 
 ### Options
 
-| 参数         | 说明                          | 类型                  | 默认值   |
-|--------------|-------------------------------|-----------------------|----------|
-| navigateMode | 状态变更时切换 history 的方式 | `'push' \| 'replace'` | `'push'` |
-| parseOptions | `query-string`parse的配置 | `ParseOptions` | - |
-| stringifyOptions | `query-string`stringify的配置 | `StringifyOptions` | - |
+| 参数             | 说明                                                                                                    | 类型                  | 默认值   |
+|------------------|---------------------------------------------------------------------------------------------------------|-----------------------|----------|
+| navigateMode     | 状态变更时切换 history 的方式                                                                           | `'push' \| 'replace'` | `'push'` |
+| parseOptions     | `query-string` [parse](https://github.com/sindresorhus/query-string#parsestring-options) 的配置         | `ParseOptions`        | -        |
+| stringifyOptions | `query-string` [stringify](https://github.com/sindresorhus/query-string#stringifyobject-options) 的配置 | `StringifyOptions`    | -        |
 
 ### Result
 

--- a/packages/use-url-state/use-url-state.zh-CN.md
+++ b/packages/use-url-state/use-url-state.zh-CN.md
@@ -43,6 +43,10 @@ React Router V6：https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 
 <code src="./demo/demo2.tsx" hideActions='["CSB"]' />
 
+### 处理数组类型的url query
+
+<code src="./demo/demo3.tsx" hideActions='["CSB"]' />
+
 ## API
 
 ```typescript
@@ -61,6 +65,8 @@ const [state, setState] = useUrlState(initialState, options);
 | 参数         | 说明                          | 类型                  | 默认值   |
 |--------------|-------------------------------|-----------------------|----------|
 | navigateMode | 状态变更时切换 history 的方式 | `'push' \| 'replace'` | `'push'` |
+| parseOptions | `query-string`parse的配置 | `ParseOptions` | - |
+| stringifyOptions | `query-string`stringify的配置 | `StringifyOptions` | - |
 
 ### Result
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

自定义处理数组类型的url quey需要使用到`query-string`的parseOptions和stringifyOptions

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 | options添加query-string的parseOptions和stringifyOptions配置项|

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供