### PR TITLE
feat: add fetchKey to useRequest

### DIFF
--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -1,5 +1,12 @@
 import type { MutableRefObject } from 'react';
-import type { FetchState, Options, PluginReturn, Service, Subscribe } from './types';
+import type {
+  FetchState,
+  Options,
+  PluginReturn,
+  Service,
+  Subscribe,
+  FetchSubscribe,
+} from './types';
 
 export default class Fetch<TData, TParams extends any[]> {
   pluginImpls: PluginReturn<TData, TParams>[];
@@ -16,7 +23,7 @@ export default class Fetch<TData, TParams extends any[]> {
   constructor(
     public serviceRef: MutableRefObject<Service<TData, TParams>>,
     public options: Options<TData, TParams>,
-    public subscribe: Subscribe,
+    public subscribe: Subscribe | FetchSubscribe<TData, TParams>,
     public initState: Partial<FetchState<TData, TParams>> = {},
   ) {
     this.state = {
@@ -27,11 +34,14 @@ export default class Fetch<TData, TParams extends any[]> {
   }
 
   setState(s: Partial<FetchState<TData, TParams>> = {}) {
-    this.state = {
+    const newState = {
       ...this.state,
       ...s,
     };
-    this.subscribe();
+    this.state = newState;
+    if (newState.params && this.options.fetchKey) {
+      this.subscribe(this.options.fetchKey(...newState.params), this.state);
+    }
   }
 
   runPluginHandler(event: keyof PluginReturn<TData, TParams>, ...rest: any[]) {

--- a/packages/hooks/src/useRequest/src/types.ts
+++ b/packages/hooks/src/useRequest/src/types.ts
@@ -4,6 +4,10 @@ import type { CachedData } from './utils/cache';
 
 export type Service<TData, TParams extends any[]> = (...args: TParams) => Promise<TData>;
 export type Subscribe = () => void;
+export type FetchSubscribe<TData, TParams extends any[]> = (
+  fetchKey: string,
+  fetchState: FetchState<TData, TParams>,
+) => void;
 
 // for Fetch
 
@@ -88,7 +92,7 @@ export interface Options<TData, TParams extends any[]> {
 
   // ready
   ready?: boolean;
-
+  fetchKey?: (...params: TParams) => string;
   // [key: string]: any;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->


### 💡 Background and solution
虽然期望是 [原 options.fetchKey 并行模式删除，期望将每个请求动作和 UI 封装为一个组件，而不是把所有请求都放到父级](https://ahooks.js.org/zh-CN/guide/upgrade#faq)，但我们业务仍期望使用 useRequest 做父层并发请求

我们在调用 [阿里 api 批量获取商品详细信息](https://open.taobao.com/api.htm?docId=24626&docType=2) 时，有数量限制，只能分批请求，从 ahooks 2.x 升到 3.x，没有 fetchKey 的话，成本太大

我个人认为官方删除 fetchKey 的理由也不够有说服力

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/26433572/153747383-06030f6a-72a1-48dc-a50c-925f8cc7dbd6.png">


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    feat: add fetchKey to useRequest    |
| 🇨🇳 Chinese |   feat: 恢复 useRequest 的 fetchKey 功能        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
