### PR TITLE
fix: useMemoizedFn return a plain function type

### DIFF
--- a/packages/hooks/src/useMemoizedFn/index.ts
+++ b/packages/hooks/src/useMemoizedFn/index.ts
@@ -2,6 +2,11 @@ import { useMemo, useRef } from 'react';
 
 type noop = (this: any, ...args: any[]) => any;
 
+type PickFunction<T extends noop> = (
+  this: ThisParameterType<T>,
+  ...args: Parameters<T>
+) => ReturnType<T>;
+
 function useMemoizedFn<T extends noop>(fn: T) {
   if (process.env.NODE_ENV === 'development') {
     if (typeof fn !== 'function') {
@@ -15,11 +20,11 @@ function useMemoizedFn<T extends noop>(fn: T) {
   // https://github.com/alibaba/hooks/issues/728
   fnRef.current = useMemo(() => fn, [fn]);
 
-  const memoizedFn = useRef<T>();
+  const memoizedFn = useRef<PickFunction<T>>();
   if (!memoizedFn.current) {
     memoizedFn.current = function (this, ...args) {
       return fnRef.current.apply(this, args);
-    } as T;
+    };
   }
 
   return memoizedFn.current;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] Bug fix

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->


我们考察如下代码

```tsx
export default function App() {
  const fn = () => {
    console.log("hello");
  };

  fn.hello = "hello"; // fn: {():void,hello: string}

  const memoizedFn = useMemoizedFn(fn); 

  return (
    <div>
      <div>{`${fn.hello}` /* hello */}</div>
      <div>{`${memoizedFn.hello}` /* undefined */}</div>
    </div>
  );
}
```

TypeScript 推导出 `memoizedFn.hello` 为**不可空**的 `string`, 但实际访问则是 `undefined`。
如果 `memoizedFn.hello` 还是个对象，继续使用 `.` 运算符，那么还会有更可怕的**异常**发生。

https://github.com/alibaba/hooks/blob/cbc8f8f9530c3c5aa1f0ce7656c9e991eec7bc41/packages/hooks/src/useMemoizedFn/index.ts#L20-L22

原来的代码，由于使用的类型强制转换，导致类型推导出现错误，我们这里的返回值类型，应该剔除 fn 对象中的所有属性，而只保留其函数的部分。

因此我们可以定义一个 ts type，它的泛型参数可以接受任意函数对象，然后转换成一个普通的函数

```ts
type PickFunction<T extends noop> = (
  this: ThisParameterType<T>,
  ...args: Parameters<T>
) => ReturnType<T>;
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
