### PR TITLE
refactor: usePrevious defaultShouldUpdate for objects

### DIFF
--- a/packages/hooks/src/usePrevious/index.ts
+++ b/packages/hooks/src/usePrevious/index.ts
@@ -1,8 +1,9 @@
+import isEqual from 'lodash/isEqual';
 import { useRef } from 'react';
 
 export type ShouldUpdateFunc<T> = (prev: T | undefined, next: T) => boolean;
 
-const defaultShouldUpdate = <T>(a?: T, b?: T) => a !== b;
+const defaultShouldUpdate = <T>(a?: T, b?: T) => !isEqual(a, b);
 
 function usePrevious<T>(
   state: T,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Improvement suggestion for [this refactor](https://github.com/alibaba/hooks/pull/1065/files#diff-ad519196882286b4357ae17509e738d00997dfa78c635093e58db96628ab7229L9-R14).

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
This PR is an update suggestion to prevent an extra update on usePrevious using objects.


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     [The previous refactor](https://github.com/alibaba/hooks/pull/1065/files#diff-ad519196882286b4357ae17509e738d00997dfa78c635093e58db96628ab7229L9-R14) introduced a potential "Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render." depending on how deps were used. This PR doesn't fix this regression/breaking change. It can be fixed by `useMemo` or `usePrevious(..., () => true)` as a workaround     |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
