### PR TITLE
fix(useVirtualList): set overscan: 0, the first data will not be rendered

### DIFF
--- a/packages/hooks/src/useVirtualList/__tests__/index.test.ts
+++ b/packages/hooks/src/useVirtualList/__tests__/index.test.ts
@@ -66,7 +66,7 @@ describe('useVirtualList', () => {
       expect(container.scrollTop).toBe(80 * 30);
     });
 
-    it('test with fixed height', () => {
+    it('test with fixed height when overscan equals 0', () => {
       setup(Array.from(Array(99999).keys()), {
         overscan: 0,
         itemHeight: 30,
@@ -79,10 +79,28 @@ describe('useVirtualList', () => {
       });
 
       expect(hook.result.current[0].length).toBe(10);
+      expect(wrapper.style.marginTop).toBe(20 * 30 + 'px');
       expect(container.scrollTop).toBe(20 * 30);
     });
 
-    it('test with dynamic height', () => {
+    it('test with fixed height when overscan equals 1', () => {
+      setup(Array.from(Array(99999).keys()), {
+        overscan: 1,
+        itemHeight: 30,
+        containerTarget: () => container,
+        wrapperTarget: () => wrapper,
+      });
+
+      act(() => {
+        hook.result.current[1](20);
+      });
+
+      expect(hook.result.current[0].length).toBe(300 / 30 + 2);
+      expect(wrapper.style.marginTop).toBe(20 * 30 - 30 * 1 + 'px');
+      expect(container.scrollTop).toBe(20 * 30);
+    });
+
+    it('test with dynamic height when overscan equals 0', () => {
       setup(Array.from(Array(99999).keys()), {
         overscan: 0,
         containerTarget: () => container,
@@ -97,7 +115,7 @@ describe('useVirtualList', () => {
       // average height for easy calculation
       const averageHeight = (30 + 60) / 2;
 
-      expect(hook.result.current[0].length).toBe(Math.floor(300 / averageHeight));
+      expect(hook.result.current[0].length).toBe(Math.ceil(300 / averageHeight));
       expect(container.scrollTop).toBe(10 * 30 + 10 * 60);
       expect((hook.result.current[0][0] as { data: number }).data).toBe(20);
       expect((hook.result.current[0][0] as { index: number }).index).toBe(20);
@@ -106,6 +124,28 @@ describe('useVirtualList', () => {
 
       expect(wrapper.style.marginTop).toBe(20 * averageHeight + 'px');
       expect(wrapper.style.height).toBe((99998 - 20) * averageHeight + 30 + 'px');
+    });
+
+    it('test with dynamic height when overscan equals 1', () => {
+      setup(Array.from(Array(99999).keys()), {
+        overscan: 1,
+        containerTarget: () => container,
+        wrapperTarget: () => wrapper,
+        itemHeight: (i: number) => (i % 2 === 0 ? 30 : 60),
+      });
+
+      act(() => {
+        hook.result.current[1](20);
+      });
+
+      // average height for easy calculation
+      const averageHeight = (30 + 60) / 2;
+
+      expect(hook.result.current[0].length).toBe(Math.ceil(300 / averageHeight) + 2);
+      expect(container.scrollTop).toBe(10 * 30 + 10 * 60);
+
+      expect(wrapper.style.marginTop).toBe(20 * averageHeight - 60 + 'px');
+      expect(container.scrollTop).toBe(20 * averageHeight);
     });
   });
 });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix: https://github.com/alibaba/hooks/issues/1538

### 💡 需求背景和解决方案

原代码在计算可视区域展示的list数量有错误。

* `overscan`为0时，第一条未展示
* `container`高度为`300` ，  `itemHeight`的高度为 `(i: number) => (i % 2 === 0 ? 30 : 60)` 单测中期望的条目数是`6`，实际应该是`7`（30 + 60 + 30 + 60 + 30 + 60  + 30 = 300）。

下面截图展示下计算高度的场景下 `overscan` 在不同情况修下，原代码和调整后展示的条目数

> overscan 为 0
原效果
<img width="1978" alt="image" src="https://user-images.githubusercontent.com/22162984/162582665-7267ed14-064b-4f15-9aeb-c2e82484922c.png">
现效果
<img width="1999" alt="image" src="https://user-images.githubusercontent.com/22162984/162582700-f6713bb3-20e1-4f17-97b6-a1352555d9b6.png">

> overscan 为 1
原效果。在滚动到如图位置中时，可视区域展示的是 3-7 则在`overscan`为`1`的情况修下，上方缺少了`Row: 2 size: small`

<img width="2328" alt="image" src="https://user-images.githubusercontent.com/22162984/162582778-20aae879-7fce-445c-b9ab-34b8fc6aa4a4.png">

现效果

<img width="2270" alt="image" src="https://user-images.githubusercontent.com/22162984/162582906-e3dc6110-9f51-4f23-83ec-cb9a75dac109.png">

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    fix  visible area calc list number error    |
| 🇨🇳 中文 |    修复可视区域计算列表数量的错误    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供