### PR TITLE
fix:  useInfiniteScroll的target为document的计算

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -79,7 +79,7 @@ const useInfiniteScroll = <TData extends Data>(
   const reloadAsync = () => runAsync();
 
   const scrollMethod = () => {
-    const el = getTargetElement(target);
+    const el = target === document ? document.documentElement : getTargetElement(target);
     if (!el) {
       return;
     }


### PR DESCRIPTION

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 计算target的scrollTop, scrollHeight, clientHeight 是有问题的

- [ ] Bug fix

### 🔗 Related issue link

https://github.com/alibaba/hooks/issues/1563

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

fix:  useInfiniteScroll的target为document时，阈值计算修复

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
