### PR TITLE
fix: fixed an issue with datasource default value change

### DIFF
--- a/packages/hooks/src/useAntdTable/index.tsx
+++ b/packages/hooks/src/useAntdTable/index.tsx
@@ -38,6 +38,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
   const [type, setType] = useState(cacheFormTableData?.type || defaultType);
 
   const allFormDataRef = useRef<Record<string, any>>({});
+  const defaultDataSource = useRef([]);
 
   const isAntdV4 = !!form?.getInternalHooks;
 
@@ -234,7 +235,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
   return {
     ...result,
     tableProps: {
-      dataSource: result.data?.list || [],
+      dataSource: result.data?.list || defaultDataSource.current,
       loading: result.loading,
       onChange: useMemoizedFn(onTableChange),
       pagination: {

--- a/packages/hooks/src/useAntdTable/index.tsx
+++ b/packages/hooks/src/useAntdTable/index.tsx
@@ -38,7 +38,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
   const [type, setType] = useState(cacheFormTableData?.type || defaultType);
 
   const allFormDataRef = useRef<Record<string, any>>({});
-  const defaultDataSource = useRef([]);
+  const defaultDataSourceRef = useRef([]);
 
   const isAntdV4 = !!form?.getInternalHooks;
 

--- a/packages/hooks/src/useAntdTable/index.tsx
+++ b/packages/hooks/src/useAntdTable/index.tsx
@@ -235,7 +235,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
   return {
     ...result,
     tableProps: {
-      dataSource: result.data?.list || defaultDataSource.current,
+      dataSource: result.data?.list || defaultDataSourceRef.current,
       loading: result.loading,
       onChange: useMemoizedFn(onTableChange),
       pagination: {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

需要格式化useAntdTable的返回结果，当使用tableProps.dataSource作为useEffect的依赖项的时候，ussEffect的内部代码重复被执行，检查后发现是因为dataSource的默认值是[]，每次依赖更新都是一个新的地址，我在源码中添加了一个ref来解决这个问题。

我写了一个重现：
https://codesandbox.io/s/vibrant-rosalind-jv55sb?file=/src/index.js

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

