### PR TITLE
feat: createUseStorageState support hook state sync between some tabs

### DIFF
--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-empty */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 import useUpdateEffect from '../useUpdateEffect';
 import { isFunction } from '../utils';
@@ -96,6 +96,27 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
         }
       }
     };
+
+    useEffect(() => {
+      const handleStorage = (event: StorageEvent) => {
+        if (event.storageArea === storage) {
+          // handle clear event
+          if (event.key === null) {
+            setState(undefined);
+          } else if (event.key === key) {
+            // handle removeItem event
+            if (event.newValue === null) {
+              setState(undefined);
+            } else {
+              setState(deserializer(event.newValue));
+            }
+          }
+        }
+      };
+
+      window.addEventListener('storage', handleStorage);
+      return () => window.removeEventListener('storage', handleStorage);
+    }, []);
 
     return [state, useMemoizedFn(updateState)];
   }

--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -67,6 +67,16 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
         return options?.defaultValue();
       }
       return options?.defaultValue;
+
+      // if (options?.defaultValue === undefined) {
+      //   return;
+      // }
+      // const value = isFunction(options?.defaultValue)
+      //   ? options?.defaultValue()
+      //   : options?.defaultValue;
+
+      // storage?.setItem(key, serializer(value));
+      // return value;
     }
 
     const [state, setState] = useState<T | undefined>(() => getStoredValue());
@@ -78,11 +88,35 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
     const updateState = (value?: T | IFuncUpdater<T>) => {
       if (typeof value === 'undefined') {
         setState(undefined);
+
+        const se = new StorageEvent('storage', {
+          cancelable: false,
+          bubbles: false,
+          key,
+          newValue: null,
+          oldValue: storage?.getItem(key),
+          storageArea: storage,
+          url: location.href,
+        });
+        window.dispatchEvent(se);
+
         storage?.removeItem(key);
       } else if (isFunction(value)) {
         const currentState = value(state);
         try {
           setState(currentState);
+
+          const se = new StorageEvent('storage', {
+            cancelable: false,
+            bubbles: false,
+            key,
+            newValue: serializer(currentState),
+            oldValue: storage?.getItem(key),
+            storageArea: storage,
+            url: location.href,
+          });
+          window.dispatchEvent(se);
+
           storage?.setItem(key, serializer(currentState));
         } catch (e) {
           console.error(e);
@@ -90,6 +124,18 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
       } else {
         try {
           setState(value);
+
+          const se = new StorageEvent('storage', {
+            cancelable: false,
+            bubbles: false,
+            key,
+            newValue: serializer(value),
+            oldValue: storage?.getItem(key),
+            storageArea: storage,
+            url: location.href,
+          });
+          window.dispatchEvent(se);
+
           storage?.setItem(key, serializer(value));
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution


1. I found the hook state from one tab not update，while i using the same hook instance from another tab.
2. use storage addEventListener to receive update from another tab


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
