### PR TITLE
fix: useInfiniteScroll 在 reloadDeps 发生变化时需要清空已有数据

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -105,6 +105,7 @@ const useInfiniteScroll = <TData extends Data>(
   );
 
   useUpdateEffect(() => {
+    setFinalData(undefined);
     run();
   }, [...reloadDeps]);
 


### PR DESCRIPTION
useInfiniteScroll 作为列表，并有查询条件。

否则查询条件发生变更需要重新从后端读取数据并展示到界面时会返回两次
第一次返回是最新的数据，第二次返回的是上一次未被清空的数据

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
