### PR TITLE
feat(useMount): 保证副作用只执行一次

### DIFF
--- a/packages/hooks/src/useMount/index.ts
+++ b/packages/hooks/src/useMount/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { isFunction } from '../utils';
 
 const useMount = (fn: () => void) => {
@@ -10,8 +10,13 @@ const useMount = (fn: () => void) => {
     }
   }
 
+  const executedRef = useRef(false);
+
   useEffect(() => {
-    fn?.();
+    if (!executedRef.current) {
+      fn?.();
+      executedRef.current = true;
+    }
   }, []);
 };
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/alibaba/hooks/issues/1628

### 💡 Background and solution

1. Describe the problem and the scenario.
在 React v18中，开启严格模式、处于开发环境下，**组件卸载之前**，`useEffect(() => { fn(); return cleanUp }, [])` 会依次执行 `fn()` -> `cleanUp()` ->  `fn()`，但是其他环境下只执行 `fn()`
2. GIF or snapshot should be provided if includes UI/interactive modification.
https://user-images.githubusercontent.com/40132433/174477922-63befc3b-0416-4ab3-9d44-45134a8e6500.mov
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
通过标识 `executedRef` 保证任何情况下副作用都只执行一次

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
