### PR TITLE
feat: usePromise

### DIFF
--- a/config/hooks.ts
+++ b/config/hooks.ts
@@ -110,6 +110,7 @@ export const menus = [
       'useLatest',
       'useMemoizedFn',
       'useReactive',
+      'usePromise',
     ],
   },
   {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -44,6 +44,7 @@ import useMouse from './useMouse';
 import useNetwork from './useNetwork';
 import usePagination from './usePagination';
 import usePrevious from './usePrevious';
+import usePromise from './usePromise';
 import useRafInterval from './useRafInterval';
 import useRafState from './useRafState';
 import useRafTimeout from './useRafTimeout';
@@ -98,6 +99,7 @@ export {
   useDebounceFn,
   useDebounceEffect,
   usePrevious,
+  usePromise,
   useMouse,
   useScroll,
   useClickAway,

--- a/packages/hooks/src/usePromise/__tests__/index.test.ts
+++ b/packages/hooks/src/usePromise/__tests__/index.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useEffect } from 'react';
+import usePromise, { AbortedErrorMessage, InvokeInRenderErrorMessage } from '../index';
+
+function createPromise(val: string) {
+  return new Promise<string>((resolve) => {
+    process.nextTick(() => resolve('Resolve: ' + val));
+  });
+}
+const flushPromises = () => new Promise(setImmediate);
+
+describe('usePromise', () => {
+  it('should be defined', () => {
+    expect(usePromise).toBeDefined();
+  });
+
+  jest.useFakeTimers();
+
+  function getHook() {
+    const results = {};
+    const hook = renderHook(
+      ({ val }: { val: string }) => {
+        if (!results[val]) results[val] = [];
+        const getPromise = usePromise(() => createPromise(val), [val]);
+        useEffect(() => {
+          getPromise()
+            .then((value) => results[val].push('Then:' + value))
+            .catch((error) => results[val].push('Catch:' + error));
+        }, [getPromise]);
+      },
+      { initialProps: { val: 'test1' } },
+    );
+    return { hook, results };
+  }
+
+  it('test resolve', async () => {
+    const { results, hook } = getHook();
+    expect(results).toEqual({ test1: [] });
+
+    await flushPromises();
+    expect(results).toEqual({ test1: ['Then:Resolve: test1'] });
+
+    hook.rerender({ val: 'test2' });
+    await flushPromises();
+    expect(results).toEqual({
+      test1: ['Then:Resolve: test1'],
+      test2: ['Then:Resolve: test2'],
+    });
+  });
+
+  it('test unmount', async () => {
+    const { results, hook } = getHook();
+    expect(results).toEqual({ test1: [] });
+    hook.unmount();
+    await flushPromises();
+    expect(results).toEqual({ test1: ['Catch:Error: ' + AbortedErrorMessage] });
+  });
+
+  it('test rerender', async () => {
+    const { results, hook } = getHook();
+    expect(results).toEqual({ test1: [] });
+    hook.rerender({ val: 'test2' });
+    expect(results).toEqual({ test1: [], test2: [] });
+    await flushPromises();
+    expect(results).toEqual({
+      test1: ['Catch:Error: ' + AbortedErrorMessage],
+      test2: ['Then:Resolve: test2'],
+    });
+  });
+
+  function getIncorrectHook() {
+    const onError = jest.fn();
+    const hook = renderHook(
+      ({ val }: { val: string }) => {
+        const getPromise = usePromise(() => createPromise(val), [val]);
+        try {
+          getPromise();
+        } catch (error) {
+          onError('Catch:' + error);
+        }
+      },
+      { initialProps: { val: 'test1' } },
+    );
+    return { hook, onError };
+  }
+
+  it('test incorrect usage', async () => {
+    const { onError } = getIncorrectHook();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toBeCalledWith('Catch:Error: ' + InvokeInRenderErrorMessage);
+  });
+
+  function getMemoHook() {
+    const onEffect = jest.fn();
+    const hook = renderHook(
+      ({ val }: { val: string; val2: string }) => {
+        const getPromise = usePromise(() => createPromise(val), [val]);
+        useEffect(() => {
+          onEffect();
+          getPromise().then(() => {});
+        }, [getPromise]);
+      },
+      { initialProps: { val: 'test1', val2: 'any' } },
+    );
+    return { hook, onEffect };
+  }
+
+  it('test memo behavior', async () => {
+    const { onEffect, hook } = getMemoHook();
+    expect(onEffect).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+    hook.rerender({ val: 'test1', val2: 'any2' });
+    expect(onEffect).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+    hook.rerender({ val: 'test1', val2: 'any3' });
+    expect(onEffect).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+    hook.rerender({ val: 'test2', val2: 'any3' });
+    expect(onEffect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/hooks/src/usePromise/demo/demo1.tsx
+++ b/packages/hooks/src/usePromise/demo/demo1.tsx
@@ -1,0 +1,39 @@
+import { usePromise } from 'ahooks';
+import React, { useEffect, useState } from 'react';
+
+function fakefetch(url: string) {
+  return new Promise<string>((resolve) => {
+    setTimeout(() => resolve('Fetched: ' + url), url.length % 2 === 0 ? 1000 : 500);
+  });
+}
+
+function Page({ pageId }: { pageId: string }) {
+  const [data, setData] = useState<string | null>(null);
+  const fetchPage = usePromise(() => fakefetch('/api/' + pageId), [pageId]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setData(await fetchPage());
+      } catch (_) {}
+    })();
+  }, [fetchPage]);
+
+  return (
+    <section>
+      <h1>{pageId}</h1>
+      <article>{!data ? 'loading' : data}</article>
+    </section>
+  );
+}
+
+export default () => {
+  const [pageId, setPageId] = useState('');
+
+  return (
+    <main>
+      <button onClick={() => setPageId(pageId + pageId.length)}>Click</button>
+      <Page pageId={pageId} />
+    </main>
+  );
+};

--- a/packages/hooks/src/usePromise/index.en-US.md
+++ b/packages/hooks/src/usePromise/index.en-US.md
@@ -1,0 +1,23 @@
+---
+nav:
+  path: /hooks
+---
+
+# usePromise
+
+Use promises with React lifecycle to avoid race condition and memory leak.
+
+## Examples
+
+### Default usage
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+const getPromise: () => R = usePromise<R extends Promise<any>>(
+  callback: () => R,
+  deps: React.DependencyList
+);
+```

--- a/packages/hooks/src/usePromise/index.tsx
+++ b/packages/hooks/src/usePromise/index.tsx
@@ -1,0 +1,40 @@
+import type { DependencyList } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
+
+export const AbortedErrorMessage = 'The promise has been aborted';
+export const InvokeInRenderErrorMessage = "Don't invoke this callback in rendering";
+
+function abortablePromise<T extends Promise<any>>(promise: T, controller: AbortController): T {
+  const signal = controller.signal;
+  if (signal.aborted) return Promise.reject(new Error(AbortedErrorMessage)) as T;
+
+  return new Promise((resolve, reject) => {
+    signal.addEventListener('abort', () => {
+      reject(new Error(AbortedErrorMessage));
+    });
+    promise.then(resolve).catch(reject);
+  }) as T;
+}
+
+interface GetPromise<R extends Promise<any>> {
+  (): R;
+  abortController?: AbortController;
+}
+
+export default function usePromise<R extends Promise<any>>(
+  callback: () => R,
+  deps: DependencyList,
+): () => R {
+  const getPromise: GetPromise<R> = useCallback(() => {
+    const promise = callback();
+    if (getPromise.abortController == null) throw new Error(InvokeInRenderErrorMessage);
+    return abortablePromise(promise, getPromise.abortController);
+  }, deps);
+
+  useLayoutEffect(() => {
+    const abortController = new AbortController();
+    getPromise.abortController = abortController;
+    return () => abortController.abort();
+  }, [getPromise]);
+  return getPromise;
+}

--- a/packages/hooks/src/usePromise/index.zh-CN.md
+++ b/packages/hooks/src/usePromise/index.zh-CN.md
@@ -1,0 +1,23 @@
+---
+nav:
+  path: /hooks
+---
+
+# useDeepCompareLayoutEffect
+
+在 React 的生命週期中使用 Promise 来避免竞争条件和内存泄露。
+
+## 代码演示
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+```typescript
+const getPromise: () => R = usePromise<R extends Promise<any>>(
+  callback: () => R,
+  deps: React.DependencyList
+);
+```


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a new hook - usePromise

- [x] New feature

### 🔗 Related issue link

Use [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) in React like in `useEffect` or event handlers can cause race condition and memory leak if without cleaning up promises correctly.
[This article](https://maxrozen.com/race-conditions-fetching-data-react-with-useeffect) explains the issues well.
Developers can define `AbortController` and clean it up by themselves, but it's tedious and can't be used in event handlers easily.

### 💡 Background and solution
Please check [this GIF](https://giphy.com/gifs/dYfRmZ249Yqw4vDa46) to demonstrate the race condition. The code [is here](https://codesandbox.io/s/usepromise-96t1qv?file=/src/App.tsx).
`usePromise` from `react-use` can only solve memory leak but can't solve race condition.

Solution is wrapping the promise like `fetch` in `usePromise` and then get the promise later. The wrapping promise will be aborted if the obsolete `deps` invalidate the promise in re-rendering.
```tsx
import { usePromise } from 'ahooks';

function Page({ pageId }: { pageId: string }) {
  const [data, setData] = useState<string | null>(null);
  const fetchPage = usePromise(() => fetch("/api/" + pageId), [pageId]);

  useEffect(() => {
    (async () => {
      try {
        setData(await fetchPage());
      } catch (_) {}
    })();
  }, [fetchPage]);
}
```
### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
