### PR TITLE
简化 useBoolean 方法，可减少声明的方法

### DIFF
--- a/packages/hooks/src/useBoolean/index.ts
+++ b/packages/hooks/src/useBoolean/index.ts
@@ -2,25 +2,24 @@ import { useMemo } from 'react';
 import useToggle from '../useToggle';
 
 export interface Actions {
-  setTrue: () => void;
-  setFalse: () => void;
-  set: (value: boolean) => void;
-  toggle: () => void;
+ setTrue: () => void;
+ setFalse: () => void;
+ set: (value: boolean) => void;
+ toggle: () => void;
 }
 
 export default function useBoolean(defaultValue = false): [boolean, Actions] {
-  const [state, { toggle, set }] = useToggle(defaultValue);
+ const [state, { toggle, set, setLeft, setRight }] = useToggle(defaultValue);
 
-  const actions: Actions = useMemo(() => {
-    const setTrue = () => set(true);
-    const setFalse = () => set(false);
-    return {
-      toggle,
-      set: (v) => set(!!v),
-      setTrue,
-      setFalse,
-    };
-  }, []);
+ const actions: Actions = useMemo(() => {
+  const [setTrue, setFalse] = !defaultValue ? [setRight, setLeft] : [setLeft, setRight];
+  return {
+   toggle,
+   set: (v) => set(!!v),
+   setTrue,
+   setFalse,
+  };
+ }, []);
 
-  return [state, actions];
+ return [state, actions];
 }

--- a/packages/hooks/src/useBoolean/index.ts
+++ b/packages/hooks/src/useBoolean/index.ts
@@ -2,24 +2,24 @@ import { useMemo } from 'react';
 import useToggle from '../useToggle';
 
 export interface Actions {
- setTrue: () => void;
- setFalse: () => void;
- set: (value: boolean) => void;
- toggle: () => void;
+  setTrue: () => void;
+  setFalse: () => void;
+  set: (value: boolean) => void;
+  toggle: () => void;
 }
 
 export default function useBoolean(defaultValue = false): [boolean, Actions] {
- const [state, { toggle, set, setLeft, setRight }] = useToggle(defaultValue);
+  const [state, { toggle, set, setLeft, setRight }] = useToggle(defaultValue);
 
- const actions: Actions = useMemo(() => {
-  const [setTrue, setFalse] = !defaultValue ? [setRight, setLeft] : [setLeft, setRight];
-  return {
-   toggle,
-   set: (v) => set(!!v),
-   setTrue,
-   setFalse,
-  };
- }, []);
+  const actions: Actions = useMemo(() => {
+    const [setTrue, setFalse] = !defaultValue ? [setRight, setLeft] : [setLeft, setRight];
+    return {
+      toggle,
+      set: (v) => set(!!v),
+      setTrue,
+      setFalse,
+    };
+  }, []);
 
- return [state, actions];
+  return [state, actions];
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 重构

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
  useToggle 函数已经返回了 setLeft, setRight 方法，可通过判断用户传入的 defaultValue 值来判断哪一个对应着 setTrue 或 setFalse ，例如说： defaultValue 是默认值 false, 那么 setTrue 即 setRight ；若 defaultValue 是 true ，那么 setTrue 即 setLeft 。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- 文档已补充或无须补充
- 代码演示已提供或无须提供
- TypeScript 定义已补充或无须补充
- Changelog 已提供或无须提供
