### PR TITLE
docs: fix the bug that the text out of document without line break

### DIFF
--- a/packages/hooks/src/useWebSocket/demo/demo1.tsx
+++ b/packages/hooks/src/useWebSocket/demo/demo1.tsx
@@ -46,7 +46,9 @@ export default () => {
       <div style={{ marginTop: 8 }}>
         <p>received message: </p>
         {messageHistory.current.map((message, index) => (
-          <p key={index}>{message?.data}</p>
+          <p key={index} style={{ wordWrap: 'break-word' }}>
+            {message?.data}
+          </p>
         ))}
       </div>
     </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the bug that the text out of document without line break  |
| 🇨🇳 Chinese | 修复文档中的文本没有换行的bug |


before:
![image](https://user-images.githubusercontent.com/38075730/184367107-08bbd4d5-382c-47a2-b701-27728373bfa8.png)
after:
![image](https://user-images.githubusercontent.com/38075730/184367128-8471301f-c4dd-466c-b325-e1e3e7654051.png)

image
### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed





































