### PR TITLE
fix: add defaultDataSourceRef

### DIFF
--- a/packages/use-request/src/usePaginated.ts
+++ b/packages/use-request/src/usePaginated.ts
@@ -40,6 +40,8 @@ function usePaginated<R, Item, U extends Item = any>(
     ...(restOptions as any),
   });
 
+  const defaultDataSourceRef = useRef([]);
+
   const {
     current = 1,
     pageSize = defaultPageSize,
@@ -134,7 +136,7 @@ function usePaginated<R, Item, U extends Item = any>(
       changePageSize,
     },
     tableProps: {
-      dataSource: data?.list || [],
+      dataSource: data?.list || defaultDataSourceRef.current,
       loading,
       onChange: changeTable,
       pagination: {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
类似问题: https://github.com/alibaba/hooks/pull/1579
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在ahooks 2.x 中使用useFusionTable的时候，当使用tableProps.dataSource作为useEffect的依赖项的时候，useEffect的内部代码重复被执行，排查发现 useFusionTable给的默认值是一个普通的对象, 每次组件的刷新的时候都是新的地址, 导致useEffect 内部死循环了. 
另外, 在manual: true的条件, 一旦没有达到手动run的条件,很容易触发这个bug.

我在源码中添加ref作为默认值来解决这个问题.

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
