### PR TITLE
fix: useRequet hiding throwed errors inside onError callback function

### DIFF
--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -115,6 +115,11 @@ export default class Fetch<TData, TParams extends any[]> {
       });
 
       this.options.onError?.(error, params);
+
+      if (!this.options.onError) {
+        console.error(error);
+      }
+
       this.runPluginHandler('onError', error, params);
 
       this.options.onFinally?.(params, undefined, error);
@@ -128,11 +133,7 @@ export default class Fetch<TData, TParams extends any[]> {
   }
 
   run(...params: TParams) {
-    this.runAsync(...params).catch((error) => {
-      if (!this.options.onError) {
-        console.error(error);
-      }
-    });
+    this.runAsync(...params);
   }
 
   cancel() {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution

Sometimes You want to "rethrow" an error from the onError callback, like the example below:

```js
 onError: (error) => {
  if(error.message === 'xyz') {
    throw error;
  }
  console.log('its ok')
 }
```

But the `.catch` on inside `run()` avoid that the error "bubble ups".

The soluttion is remove the catch from `run()` and move the `console.log` to `runAsync()`

### 📝 Changelog

Previous onError callbacks that already have `throw` in it, will start to working as expected. 
So, the requests will rethrow the error causing unexpected behaviors because previously the error was being hidded

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
