### PR TITLE
修复useFullScreen当全屏后，子元素重复全屏和退出全屏操作后父元素也会退出全屏

### DIFF
--- a/packages/hooks/src/useFullscreen/__tests__/index.test.ts
+++ b/packages/hooks/src/useFullscreen/__tests__/index.test.ts
@@ -124,4 +124,55 @@ describe('useFullscreen', () => {
     unmount();
     expect(events.fullscreenchange.size).toBe(size - 1);
   });
+
+  it('`isFullscreen` should be false when use `document.exitFullscreen`', () => {
+    const { result } = setup(targetEl);
+    const { enterFullscreen } = result.current[1];
+    enterFullscreen();
+    act(() => {
+      events['fullscreenchange'].forEach((fn: any) => fn());
+    });
+    expect(result.current[0]).toBeTruthy();
+
+    document.exitFullscreen();
+    act(() => {
+      events['fullscreenchange'].forEach((fn: any) => fn());
+    });
+    expect(result.current[0]).toBeFalsy();
+  });
+
+  it('mutli element full screen should be correct', () => {
+    const targetEl2 = document.createElement('p');
+    const hook = setup(targetEl);
+    const hook2 = setup(targetEl2);
+
+    // target1 full screen
+    hook.result.current[1].enterFullscreen();
+    act(() => {
+      events['fullscreenchange'].forEach((fn: any) => fn());
+    });
+    expect(hook.result.current[0]).toBeTruthy();
+
+    // target2 full screen
+    hook2.result.current[1].enterFullscreen();
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: targetEl2,
+    });
+    act(() => {
+      events['fullscreenchange'].forEach((fn: any) => fn());
+    });
+    expect(hook.result.current[0]).toBeFalsy();
+    expect(hook2.result.current[0]).toBeTruthy();
+
+    // target2 exit full screen
+    hook2.result.current[1].exitFullscreen();
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: targetEl,
+    });
+    act(() => {
+      events['fullscreenchange'].forEach((fn: any) => fn());
+    });
+    expect(hook.result.current[0]).toBeTruthy();
+    expect(hook2.result.current[0]).toBeFalsy();
+  });
 });

--- a/packages/hooks/src/useFullscreen/index.ts
+++ b/packages/hooks/src/useFullscreen/index.ts
@@ -21,7 +21,11 @@ const useFullscreen = (target: BasicTarget, options?: Options) => {
 
   const onChange = () => {
     if (screenfull.isEnabled) {
-      const { isFullscreen } = screenfull;
+      const el = getTargetElement(target);
+      if (!el) {
+        return;
+      }
+      const isFullscreen = document.fullscreenElement === el;
       if (isFullscreen) {
         onEnterRef.current?.();
       } else {

--- a/packages/hooks/src/useFullscreen/index.ts
+++ b/packages/hooks/src/useFullscreen/index.ts
@@ -22,17 +22,20 @@ const useFullscreen = (target: BasicTarget, options?: Options) => {
   const onChange = () => {
     if (screenfull.isEnabled) {
       const el = getTargetElement(target);
-      if (!el) {
-        return;
-      }
-      const isFullscreen = document.fullscreenElement === el;
-      if (isFullscreen) {
-        onEnterRef.current?.();
-      } else {
-        screenfull.off('change', onChange);
+
+      if (!screenfull.element) {
         onExitRef.current?.();
+        setState(false);
+        screenfull.off('change', onChange);
+      } else {
+        const isFullscreen = screenfull.element === el;
+        if (isFullscreen) {
+          onEnterRef.current?.();
+        } else {
+          onExitRef.current?.();
+        }
+        setState(isFullscreen);
       }
-      setState(isFullscreen);
     }
   };
 
@@ -53,7 +56,8 @@ const useFullscreen = (target: BasicTarget, options?: Options) => {
   };
 
   const exitFullscreen = () => {
-    if (screenfull.isEnabled) {
+    const el = getTargetElement(target);
+    if (screenfull.isEnabled && screenfull.element === el) {
       screenfull.exit();
     }
   };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
修复useFullScreen当全屏后，子元素重复全屏和退出全屏操作后父元素也会退出全屏
-->

### 💡 需求背景和解决方案

```tsx
  const onChange = () => {
    if (screenfull.isEnabled) {
      const el = getTargetElement(target);
      if (!el) {
        return;
      }
      const isFullscreen = document.fullscreenElement === el;
      if (isFullscreen) {
        onEnterRef.current?.();
      } else {
        screenfull.off('change', onChange);
        onExitRef.current?.();
      }
      setState(isFullscreen);
    }
  };

```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |      Fix useFullScreen when full screen, the parent element will also exit full screen after the child element repeats the full screen and exits the full screen operation    |
| 🇨🇳 中文 |    修复useFullScreen当全屏后，子元素重复全屏和退出全屏操作后父元素也会退出全屏      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供