### PR TITLE
fix: strengthen the judgment whether it is reactRef 强化是否是reactRef的判断

### DIFF
--- a/packages/hooks/src/utils/__test__/index.spec.ts
+++ b/packages/hooks/src/utils/__test__/index.spec.ts
@@ -1,4 +1,6 @@
-import { isBoolean, isFunction, isNumber, isObject, isString, isUndef } from '../index';
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { isBoolean, isFunction, isNumber, isObject, isString, isUndef, isReactRef } from '../index';
 
 describe('shared utils methods', () => {
   test('isBoolean', () => {
@@ -52,5 +54,14 @@ describe('shared utils methods', () => {
     expect(isUndef(null)).toBe(false);
     expect(isUndef(NaN)).toBe(false);
     expect(isUndef('')).toBe(false);
+  });
+
+  test('isReactRef', () => {
+    const refHook = renderHook(() => useRef(null));
+    expect(isReactRef(refHook.result.current)).toBeTruthy();
+    const error_data1 = { base: { current: null } };
+    expect(isReactRef(error_data1)).toBeFalsy();
+    const error_data2 = { current: 'hello', current2: 'world' };
+    expect(isReactRef(error_data2)).toBeFalsy();
   });
 });

--- a/packages/hooks/src/utils/domTarget.ts
+++ b/packages/hooks/src/utils/domTarget.ts
@@ -1,5 +1,5 @@
 import type { MutableRefObject } from 'react';
-import { isFunction } from './index';
+import { isFunction, isReactRef } from './index';
 import isBrowser from './isBrowser';
 
 type TargetValue<T> = T | undefined | null;
@@ -24,9 +24,11 @@ export function getTargetElement<T extends TargetType>(target: BasicTarget<T>, d
 
   if (isFunction(target)) {
     targetElement = target();
-  } else if ('current' in target) {
+  } else if (isReactRef(target)) {
+    // @ts-ignore
     targetElement = target.current;
   } else {
+    // @ts-ignore
     targetElement = target;
   }
 

--- a/packages/hooks/src/utils/domTarget.ts
+++ b/packages/hooks/src/utils/domTarget.ts
@@ -2,9 +2,9 @@ import type { MutableRefObject } from 'react';
 import { isFunction, isReactRef } from './index';
 import isBrowser from './isBrowser';
 
-type TargetValue<T> = T | undefined | null;
+export type TargetValue<T> = T | undefined | null;
 
-type TargetType = HTMLElement | Element | Window | Document;
+export type TargetType = HTMLElement | Element | Window | Document;
 
 export type BasicTarget<T extends TargetType = Element> =
   | (() => TargetValue<T>)
@@ -25,10 +25,8 @@ export function getTargetElement<T extends TargetType>(target: BasicTarget<T>, d
   if (isFunction(target)) {
     targetElement = target();
   } else if (isReactRef(target)) {
-    // @ts-ignore
     targetElement = target.current;
   } else {
-    // @ts-ignore
     targetElement = target;
   }
 

--- a/packages/hooks/src/utils/index.ts
+++ b/packages/hooks/src/utils/index.ts
@@ -1,3 +1,6 @@
+import type { MutableRefObject } from 'react';
+import { TargetType, TargetValue } from './domTarget';
+
 export const isObject = (value: unknown): value is Record<any, any> =>
   value !== null && typeof value === 'object';
 export const isFunction = (value: unknown): value is Function => typeof value === 'function';
@@ -7,5 +10,8 @@ export const isBoolean = (value: unknown): value is boolean => typeof value === 
 export const isNumber = (value: unknown): value is number => typeof value === 'number';
 export const isUndef = (value: unknown): value is undefined => typeof value === 'undefined';
 
-export const isReactRef = (target: unknown): boolean =>
-  !!(target?.hasOwnProperty('current') && Object.keys(target).length === 1);
+export const isReactRef = <T extends TargetType>(
+  target: any,
+): target is MutableRefObject<TargetValue<T>> => {
+  return target && target?.hasOwnProperty('current') && Object.keys(target).length === 1;
+};

--- a/packages/hooks/src/utils/index.ts
+++ b/packages/hooks/src/utils/index.ts
@@ -6,3 +6,6 @@ export const isString = (value: unknown): value is string => typeof value === 's
 export const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
 export const isNumber = (value: unknown): value is number => typeof value === 'number';
 export const isUndef = (value: unknown): value is undefined => typeof value === 'undefined';
+
+export const isReactRef = (target: unknown): boolean =>
+  !!(target?.hasOwnProperty('current') && Object.keys(target).length === 1);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
感谢您的查阅。

问题：现在代码中有一些hook支持传递绑定DOM的ref对象，我观察源码中发现源码中判断是否是ref对象是使用`'current' in target`，感觉这块的判断相对粗暴了一些，可以使其更加稳健一些~

解决：根据ref的特性，封装了一个`isReactRef`的函数，用来判断是否是`ref`对象，会比`'current' in target` 更加稳健一些。并补充了对应的测试用例。
```typescript
export const isReactRef = (target: unknown): boolean =>
  !!(target?.hasOwnProperty('current') && Object.keys(target).length === 1);
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

无奈使用了两个 @ts-ignore ，如不能合并还望大佬可以指点一下。
