### PR TITLE
fix(useExternal): avoid wrong option

### DIFF
--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -1,23 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
 
-export type JsOptions = {
-  type?: 'js';
+type JsOptions = {
+  type: 'js';
   js?: Partial<HTMLScriptElement>;
 };
 
-export type CssOptions = {
-  type?: 'css';
+type CssOptions = {
+  type: 'css';
   css?: Partial<HTMLStyleElement>;
 };
 
-export type Options =
-  | CssOptions
-  | JsOptions
-  | {
-      type: never;
-      js?: Partial<HTMLScriptElement>;
-      css?: Partial<HTMLStyleElement>;
-    };
+type DefaultOptions = {
+  type?: 'js' | 'css';
+  js?: Partial<HTMLScriptElement>;
+  css?: Partial<HTMLStyleElement>;
+};
+
+type OptionsType = 'js' | 'css' | undefined;
+type Opt<T> = T extends 'js' ? JsOptions : T extends 'css' ? CssOptions : DefaultOptions;
+export type Options = Opt<OptionsType>;
 
 // {[path]: count}
 // remove external when no used
@@ -100,11 +101,11 @@ const useExternal = (path?: string, options?: Options) => {
     }
     const pathname = path.replace(/[|#].*$/, '');
     if (options?.type === 'css' || (!options?.type && /(^css!|\.css$)/.test(pathname))) {
-      const result = loadCss(path, (options as CssOptions)?.css);
+      const result = loadCss(path, options?.css);
       ref.current = result.ref;
       setStatus(result.status);
     } else if (options?.type === 'js' || (!options?.type && /(^js!|\.js$)/.test(pathname))) {
-      const result = loadScript(path, (options as JsOptions)?.js);
+      const result = loadScript(path, options?.js);
       ref.current = result.ref;
       setStatus(result.status);
     } else {

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -1,10 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 
-export interface Options {
-  type?: 'js' | 'css';
+export type JsOptions = {
+  type?: 'js';
   js?: Partial<HTMLScriptElement>;
+};
+
+export type CssOptions = {
+  type?: 'css';
   css?: Partial<HTMLStyleElement>;
-}
+};
+
+export type Options =
+  | CssOptions
+  | JsOptions
+  | {
+      type: never;
+      js?: Partial<HTMLScriptElement>;
+      css?: Partial<HTMLStyleElement>;
+    };
 
 // {[path]: count}
 // remove external when no used
@@ -87,11 +100,11 @@ const useExternal = (path?: string, options?: Options) => {
     }
     const pathname = path.replace(/[|#].*$/, '');
     if (options?.type === 'css' || (!options?.type && /(^css!|\.css$)/.test(pathname))) {
-      const result = loadCss(path, options?.css);
+      const result = loadCss(path, (options as CssOptions)?.css);
       ref.current = result.ref;
       setStatus(result.status);
     } else if (options?.type === 'js' || (!options?.type && /(^js!|\.js$)/.test(pathname))) {
-      const result = loadScript(path, options?.js);
+      const result = loadScript(path, (options as JsOptions)?.js);
       ref.current = result.ref;
       setStatus(result.status);
     } else {

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -16,9 +16,7 @@ type DefaultOptions = {
   css?: Partial<HTMLStyleElement>;
 };
 
-type OptionsType = 'js' | 'css' | undefined;
-type Opt<T> = T extends 'js' ? JsOptions : T extends 'css' ? CssOptions : DefaultOptions;
-export type Options = Opt<OptionsType>;
+export type Options = JsOptions | CssOptions | DefaultOptions;
 
 // {[path]: count}
 // remove external when no used

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -11,7 +11,7 @@ type CssOptions = {
 };
 
 type DefaultOptions = {
-  type?: 'js' | 'css';
+  type?: never;
   js?: Partial<HTMLScriptElement>;
   css?: Partial<HTMLStyleElement>;
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution
Avoid potential wrong option.

For example, if user specifies `type: 'js'` then `css` attribute is useless and will be omitted, this PR can help it at type level.

#### ❌ wrong
![image](https://user-images.githubusercontent.com/30516060/208435916-3f9ff8dc-323e-45b4-aa2f-988c3974e177.png)

#### ✅ correct
![image](https://user-images.githubusercontent.com/30516060/208436234-b59d8189-68e6-490c-a35d-68b3cef72125.png)


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
