### PR TITLE
fix: 修复useDynamicList resetList时，未重置内置key的计数

### DIFF
--- a/packages/hooks/src/useDynamicList/index.ts
+++ b/packages/hooks/src/useDynamicList/index.ts
@@ -18,6 +18,7 @@ const useDynamicList = <T>(initialList: T[] = []) => {
   });
 
   const resetList = useCallback((newList: T[]) => {
+    counterRef.current = -1;
     keyList.current = [];
     setList(() => {
       newList.forEach((_, index) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[![Edit demo for ahooks](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/ke-tuo-zhuai-de-dong-tai-biao-ge-forked-9exkje)

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
- useDynamicList在拖拽表格等场景中结合form使用。进行resetList时，由于resetList未对内置key进行重置，会导致form的values出现不符合预期的结果（重复的值等）。
- 在resetList时，重置key的计数
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
