### PR TITLE
perf: avoid force reflow in use-size

### DIFF
--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -9,7 +9,7 @@ type Size = { width: number; height: number };
 function useSize(target: BasicTarget): Size | undefined {
   const el = getTargetElement(target);
   const [state, setState] = useRafState<Size | undefined>(
-    el ? { width: el.clientWidth, height: el.clientHeight } : undefined,
+    () => el ? { width: el.clientWidth, height: el.clientHeight } : undefined,
   );
 
   useIsomorphicLayoutEffectWithTarget(

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -9,7 +9,6 @@ type Size = { width: number; height: number };
 function useSize(target: BasicTarget): Size | undefined {
   const [state, setState] = useRafState<Size | undefined>(
     () => {
-      // init size when target already exist
       const el = getTargetElement(target);
       return el ? { width: el.clientWidth, height: el.clientHeight } : undefined
     },

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -7,13 +7,18 @@ import useIsomorphicLayoutEffectWithTarget from '../utils/useIsomorphicLayoutEff
 type Size = { width: number; height: number };
 
 function useSize(target: BasicTarget): Size | undefined {
-  const el = getTargetElement(target);
   const [state, setState] = useRafState<Size | undefined>(
-    () => el ? { width: el.clientWidth, height: el.clientHeight } : undefined,
+    () => {
+      // init size when target already exist
+      const el = getTargetElement(target);
+      return el ? { width: el.clientWidth, height: el.clientHeight } : undefined
+    },
   );
 
   useIsomorphicLayoutEffectWithTarget(
     () => {
+      const el = getTargetElement(target);
+
       if (!el) {
         return;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

目前的实现会导致每次 render 都强制重新 layout，读取 el.clientWidth 的逻辑应该放进 initializer function 里防止重复调用

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
