### PR TITLE
fix(useSize): the return value is always undefined

### DIFF
--- a/packages/hooks/src/useSize/__tests__/index.test.tsx
+++ b/packages/hooks/src/useSize/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { renderHook, act, render, screen } from '@testing-library/react';
 import useSize from '../index';
 
 let callback;
@@ -14,9 +15,39 @@ jest.mock('resize-observer-polyfill', () => {
 
 // test about Resize Observer see https://github.com/que-etc/resize-observer-polyfill/tree/master/tests
 describe('useSize', () => {
-  it('with argument', () => {
+  it('should work when target is a mounted DOM', () => {
     const hook = renderHook(() => useSize(document.body));
     expect(hook.result.current).toEqual({ height: 0, width: 0 });
+  });
+
+  it('should work when target is a `MutableRefObject`', async () => {
+    const mockRaf = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+
+    function Setup() {
+      const ref = useRef(null);
+      const size = useSize(ref);
+
+      return (
+        <div ref={ref}>
+          <div>width: {String(size?.width)}</div>
+          <div>height: {String(size?.height)}</div>
+        </div>
+      );
+    }
+
+    render(<Setup />);
+    expect(await screen.findByText(/^width/)).toHaveTextContent('width: undefined');
+    expect(await screen.findByText(/^height/)).toHaveTextContent('height: undefined');
+
+    act(() => callback([{ target: { clientWidth: 10, clientHeight: 10 } }]));
+    expect(await screen.findByText(/^width/)).toHaveTextContent('width: 10');
+    expect(await screen.findByText(/^height/)).toHaveTextContent('height: 10');
+    mockRaf.mockRestore();
   });
 
   it('should not work when target is null', () => {

--- a/packages/hooks/src/useSize/index.en-US.md
+++ b/packages/hooks/src/useSize/index.en-US.md
@@ -31,6 +31,6 @@ const size = useSize(target);
 
 ### Result
 
-| Property | Description         | Type                                             |
-| -------- | ------------------- | ------------------------------------------------ |
-| size     | Size of the element | `{ width: number, height: number } \| undefined` |
+| Property | Description         | Type                                             | Default                                                                   |
+| -------- | ------------------- | ------------------------------------------------ | ------------------------------------------------------------------------- |
+| size     | Size of the element | `{ width: number, height: number } \| undefined` | `{ width: target.clientWidth, height: target.clientHeight } \| undefined` |

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -7,13 +7,15 @@ import useIsomorphicLayoutEffectWithTarget from '../utils/useIsomorphicLayoutEff
 type Size = { width: number; height: number };
 
 function useSize(target: BasicTarget): Size | undefined {
-  const el = getTargetElement(target);
+  let el = getTargetElement(target);
   const [state, setState] = useRafState<Size | undefined>(
     el ? { width: el.clientWidth, height: el.clientHeight } : undefined,
   );
 
   useIsomorphicLayoutEffectWithTarget(
     () => {
+      el = getTargetElement(target);
+
       if (!el) {
         return;
       }

--- a/packages/hooks/src/useSize/index.zh-CN.md
+++ b/packages/hooks/src/useSize/index.zh-CN.md
@@ -31,6 +31,6 @@ const size = useSize(target);
 
 ### Result
 
-| 参数 | 说明           | 类型                                             |
-| ---- | -------------- | ------------------------------------------------ |
-| size | DOM 节点的尺寸 | `{ width: number, height: number } \| undefined` |
+| 参数 | 说明           | 类型                                             | 默认值                                                                    |
+| ---- | -------------- | ------------------------------------------------ | ------------------------------------------------------------------------- |
+| size | DOM 节点的尺寸 | `{ width: number, height: number } \| undefined` | `{ width: target.clientWidth, height: target.clientHeight } \| undefined` |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

none

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

When pass a `ref` to `useSize`, the return value is `undefined` all the time.

https://user-images.githubusercontent.com/38221479/220143167-cdb7f546-038e-46ce-9991-6b64f2646dfb.mov

This was introduced by https://github.com/alibaba/hooks/pull/2057.

Maybe a test case for `ref` is missing , so I've added one by the way.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   There is no way to listen for element changes to get the DOM size in real time   |
| 🇨🇳 Chinese |   无法监听元素的改变而实时获取 DOM 尺寸    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
