### PR TITLE
fix(createUseStorageState): batched updates

### DIFF
--- a/packages/hooks/src/createUseStorageState/__tests__/index.test.ts
+++ b/packages/hooks/src/createUseStorageState/__tests__/index.test.ts
@@ -93,4 +93,15 @@ describe('useStorageState', () => {
     });
     expect(hook.result.current.state).toBeUndefined();
   });
+
+  it('should set right value when batching updates', () => {
+    const hook = setUp({ key: 'key', defaultValue: 1 });
+    act(() => {
+      hook.result.current.setState((prev) => prev + 1);
+      hook.result.current.setState((prev) => prev + 1);
+    });
+    expect(hook.result.current.state).toBe(3);
+    hook.rerender({ key: 'key' });
+    expect(hook.result.current.state).toBe(3);
+  });
 });

--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-empty */
 import { useState } from 'react';
-import useMemoizedFn from '../useMemoizedFn';
 import useUpdateEffect from '../useUpdateEffect';
 import { isFunction, isUndef } from '../utils';
 
@@ -63,22 +62,19 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
       setState(getStoredValue());
     }, [key]);
 
-    const updateState = (value: T | IFuncUpdater<T>) => {
-      const currentState = isFunction(value) ? value(state) : value;
-      setState(currentState);
-
-      if (isUndef(currentState)) {
+    useUpdateEffect(() => {
+      if (isUndef(state)) {
         storage?.removeItem(key);
       } else {
         try {
-          storage?.setItem(key, serializer(currentState));
+          storage?.setItem(key, serializer(state));
         } catch (e) {
           console.error(e);
         }
       }
-    };
+    }, [state]);
 
-    return [state, useMemoizedFn(updateState)] as const;
+    return [state, setState] as const;
   }
   return useStorageState;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix: https://github.com/alibaba/hooks/issues/2389

useLocalStorageState: Call setState(function) twice, the result is incorrect.
```js
// Currently state is increased by 1 instead of 2 after click.
const [state, setState] = useLocalStorageState('key', { defaultValue: 0 })
const click = () => {
    setState(prev => prev + 1)
    setState(prev => prev + 1)
}
```

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
