### PR TITLE
refactor(useMap/useSet): refactoring useMap and useSet for improved initialValue checking.

### DIFF
--- a/packages/hooks/src/useMap/__tests__/index.test.ts
+++ b/packages/hooks/src/useMap/__tests__/index.test.ts
@@ -26,8 +26,10 @@ describe('useMap', () => {
 
   it('should init empty map if not initial object provided', () => {
     const { result } = setup();
-
     expect([...result.current[0]]).toEqual([]);
+
+    const { result: result2 } = setup(undefined);
+    expect([...result2.current[0]]).toEqual([]);
   });
 
   it('should get corresponding value for initial provided key', () => {
@@ -131,6 +133,12 @@ describe('useMap', () => {
       ['foo', 'foo'],
       ['a', 2],
     ]);
+
+    act(() => {
+      // @ts-ignore
+      utils.setAll();
+    });
+    expect([...result.current[0]]).toEqual([]);
   });
 
   it('remove should be work', () => {
@@ -141,6 +149,24 @@ describe('useMap', () => {
       remove('msg');
     });
     expect(result.current[0].size).toBe(0);
+
+    const { result: result2 } = setup([
+      ['foo', 'bar'],
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]);
+    const [, utils] = result2.current;
+
+    act(() => {
+      utils.remove('a');
+    });
+
+    expect([...result2.current[0]]).toEqual([
+      ['foo', 'bar'],
+      ['b', 2],
+      ['c', 3],
+    ]);
   });
 
   it('reset should be work', () => {

--- a/packages/hooks/src/useMap/index.ts
+++ b/packages/hooks/src/useMap/index.ts
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useMap<K, T>(initialValue?: Iterable<readonly [K, T]>) {
-  const getInitValue = useMemo(() => new Map(initialValue), [initialValue]);
+  const getInitValue = () => new Map(initialValue);
   const [map, setMap] = useState<Map<K, T>>(getInitValue);
 
   const set = (key: K, entry: T) => {
@@ -25,7 +25,7 @@ function useMap<K, T>(initialValue?: Iterable<readonly [K, T]>) {
     });
   };
 
-  const reset = () => setMap(getInitValue);
+  const reset = () => setMap(getInitValue());
 
   const get = (key: K) => map.get(key);
 

--- a/packages/hooks/src/useMap/index.ts
+++ b/packages/hooks/src/useMap/index.ts
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useMap<K, T>(initialValue?: Iterable<readonly [K, T]>) {
-  const getInitValue = new Map(initialValue);
+  const getInitValue = useMemo(() => new Map(initialValue), [initialValue]);
   const [map, setMap] = useState<Map<K, T>>(getInitValue);
 
   const set = (key: K, entry: T) => {

--- a/packages/hooks/src/useMap/index.ts
+++ b/packages/hooks/src/useMap/index.ts
@@ -2,11 +2,8 @@ import { useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useMap<K, T>(initialValue?: Iterable<readonly [K, T]>) {
-  const getInitValue = () => {
-    return initialValue === undefined ? new Map() : new Map(initialValue);
-  };
-
-  const [map, setMap] = useState<Map<K, T>>(() => getInitValue());
+  const getInitValue = new Map(initialValue);
+  const [map, setMap] = useState<Map<K, T>>(getInitValue);
 
   const set = (key: K, entry: T) => {
     setMap((prev) => {
@@ -28,7 +25,7 @@ function useMap<K, T>(initialValue?: Iterable<readonly [K, T]>) {
     });
   };
 
-  const reset = () => setMap(getInitValue());
+  const reset = () => setMap(getInitValue);
 
   const get = (key: K) => map.get(key);
 

--- a/packages/hooks/src/useSet/__tests__/index.test.ts
+++ b/packages/hooks/src/useSet/__tests__/index.test.ts
@@ -18,8 +18,10 @@ describe('useSet', () => {
 
   it('should init empty set if no initial set provided', () => {
     const { result } = setUp();
-
     expect(result.current[0]).toEqual(new Set());
+
+    const { result: result1 } = setUp(undefined);
+    expect(result1.current[0]).toEqual(new Set());
   });
 
   it('should have an initially provided key', () => {

--- a/packages/hooks/src/useSet/index.ts
+++ b/packages/hooks/src/useSet/index.ts
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useSet<K>(initialValue?: Iterable<K>) {
-  const getInitValue = useMemo(() => new Set(initialValue), [initialValue]);
+  const getInitValue = () => new Set(initialValue);
   const [set, setSet] = useState<Set<K>>(getInitValue);
 
   const add = (key: K) => {
@@ -27,7 +27,7 @@ function useSet<K>(initialValue?: Iterable<K>) {
     });
   };
 
-  const reset = () => setSet(getInitValue);
+  const reset = () => setSet(getInitValue());
 
   return [
     set,

--- a/packages/hooks/src/useSet/index.ts
+++ b/packages/hooks/src/useSet/index.ts
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useSet<K>(initialValue?: Iterable<K>) {
-  const getInitValue = new Set(initialValue);
+  const getInitValue = useMemo(() => new Set(initialValue), [initialValue]);
   const [set, setSet] = useState<Set<K>>(getInitValue);
 
   const add = (key: K) => {

--- a/packages/hooks/src/useSet/index.ts
+++ b/packages/hooks/src/useSet/index.ts
@@ -2,11 +2,8 @@ import { useState } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 
 function useSet<K>(initialValue?: Iterable<K>) {
-  const getInitValue = () => {
-    return initialValue === undefined ? new Set<K>() : new Set(initialValue);
-  };
-
-  const [set, setSet] = useState<Set<K>>(() => getInitValue());
+  const getInitValue = new Set(initialValue);
+  const [set, setSet] = useState<Set<K>>(getInitValue);
 
   const add = (key: K) => {
     if (set.has(key)) {
@@ -30,7 +27,7 @@ function useSet<K>(initialValue?: Iterable<K>) {
     });
   };
 
-  const reset = () => setSet(getInitValue());
+  const reset = () => setSet(getInitValue);
 
   return [
     set,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
I refactored the useMap and useSet methods because the return value of new Map(undefined) is equivalent to new Map(), and the return value of new Set(undefined) is equivalent to new Set(). Therefore, I refactored the initial value checking logic in both methods.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactoring useMap and useSet for improved initialValue checking    |
| 🇨🇳 Chinese |     useMap 和 useSet 方法中改进初始值检查     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
