### PR TITLE
feat(useExternal): allow resources to remain after they have lost the…

### DIFF
--- a/packages/hooks/src/useExternal/__tests__/index.test.ts
+++ b/packages/hooks/src/useExternal/__tests__/index.test.ts
@@ -95,6 +95,18 @@ describe('useExternal', () => {
     unmount();
     expect(document.querySelector('script')).toBeNull();
   });
+  it('should not remove when keepWhenUnused is true', () => {
+    // https://github.com/alibaba/hooks/discussions/2163
+    const { result, unmount } = setup('b.js', {
+      keepWhenUnused: true,
+    });
+    const script = document.querySelector('script') as HTMLScriptElement;
+    act(() => {
+      fireEvent.load(script);
+    });
+    unmount();
+    expect(result.current).toBe('ready');
+  });
 
   it('css preload should work in IE Edge', () => {
     Object.defineProperty(HTMLLinkElement.prototype, 'hideFocus', {

--- a/packages/hooks/src/useExternal/index.en-US.md
+++ b/packages/hooks/src/useExternal/index.en-US.md
@@ -37,8 +37,9 @@ const status = useExternal(path: string, options?: Options);
 
 ### Options
 
-| Params | Description                                                                                                          | Type                | Default |
-| ------ | -------------------------------------------------------------------------------------------------------------------- | ------------------- | ------- |
-| type   | The type of external resources which need to load, support `js`/`css`, if no type, it will deduced according to path | `string`            | -       |
-| js     | Attributes supported by `script`                                                                                     | `HTMLScriptElement` | -       |
-| css    | Attributes supported by `link`                                                                                       | `HTMLStyleElement`  | -       |
+| Params         | Description                                                                                                          | Type                | Default |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------- | ------- |
+| type           | The type of external resources which need to load, support `js`/`css`, if no type, it will deduced according to path | `string`            | -       |
+| js             | Attributes supported by `script`                                                                                     | `HTMLScriptElement` | -       |
+| css            | Attributes supported by `link`                                                                                       | `HTMLStyleElement`  | -       |
+| keepWhenUnused | Allow resources to remain after they have lost their references                                                      | `boolean`           | `false` |

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -3,17 +3,20 @@ import { useEffect, useRef, useState } from 'react';
 type JsOptions = {
   type: 'js';
   js?: Partial<HTMLScriptElement>;
+  keepWhenUnused?: boolean;
 };
 
 type CssOptions = {
   type: 'css';
   css?: Partial<HTMLStyleElement>;
+  keepWhenUnused?: boolean;
 };
 
 type DefaultOptions = {
   type?: never;
   js?: Partial<HTMLScriptElement>;
   css?: Partial<HTMLStyleElement>;
+  keepWhenUnused?: boolean;
 };
 
 export type Options = JsOptions | CssOptions | DefaultOptions;
@@ -138,7 +141,7 @@ const useExternal = (path?: string, options?: Options) => {
 
       EXTERNAL_USED_COUNT[path] -= 1;
 
-      if (EXTERNAL_USED_COUNT[path] === 0) {
+      if (EXTERNAL_USED_COUNT[path] === 0 && !options?.keepWhenUnused) {
         ref.current?.remove();
       }
 

--- a/packages/hooks/src/useExternal/index.zh-CN.md
+++ b/packages/hooks/src/useExternal/index.zh-CN.md
@@ -37,8 +37,9 @@ const status = useExternal(path: string, options?: Options);
 
 ### Options
 
-| 参数 | 说明                                                              | 类型                | 默认值 |
-| ---- | ----------------------------------------------------------------- | ------------------- | ------ |
-| type | 需引入外部资源的类型，支持 `js`/`css`，如果不传，则根据 path 推导 | `string`            | -      |
-| js   | `script` 标签支持的属性                                           | `HTMLScriptElement` | -      |
-| css  | `link` 标签支持的属性                                             | `HTMLStyleElement`  | -      |
+| 参数           | 说明                                                              | 类型                | 默认值  |
+| -------------- | ----------------------------------------------------------------- | ------------------- | ------- |
+| type           | 需引入外部资源的类型，支持 `js`/`css`，如果不传，则根据 path 推导 | `string`            | -       |
+| js             | `script` 标签支持的属性                                           | `HTMLScriptElement` | -       |
+| css            | `link` 标签支持的属性                                             | `HTMLStyleElement`  | -       |
+| keepWhenUnused | 在不持有资源的引用后，仍然保留资源                                | `boolean`           | `false` |


### PR DESCRIPTION
…ir references

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [X] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

close: #2164 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add keepWhenUnused option to allow resources to remain after they have lost their references      |
| 🇨🇳 Chinese |     增加keepWhenUnused选项，允许资源在失去引用后继续保留。      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
