### PR TITLE
fix(useRequest): sync loading and error status to all related fetchInstances when cache is valid

### DIFF
--- a/packages/hooks/src/useRequest/src/utils/cacheSubscribe.ts
+++ b/packages/hooks/src/useRequest/src/utils/cacheSubscribe.ts
@@ -1,7 +1,12 @@
-type Listener = (data: any) => void;
+interface Data {
+  loading?: boolean;
+  error?: Error;
+  data?: any;
+}
+type Listener = (data: Data) => void;
 const listeners: Record<string, Listener[]> = {};
 
-const trigger = (key: string, data: any) => {
+const trigger = (key: string, data: Data) => {
   if (listeners[key]) {
     listeners[key].forEach((item) => item(data));
   }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 有个稍相关的 issue，核心诉求都是 loading、error 状态也需要能跨 useRequest 调用实例共享。本 PR 能顺带解决此 issue 提出的问题。

https://github.com/alibaba/hooks/issues/2158

### 💡 需求背景和解决方案

**以下仅讨论多个组件使用相同的 cacheKey 调用 useRequest，且缓存有效的情况**

多个 useRequest 调用实例返回相同的 data 引用，当任意 useRequest 调用实例返回的 refresh 函数被执行后，其它所有使用 useRequest 的组件都会使用最新 data 重新渲染，从而所有使用相关的组件保持状态一致。

以上是 useRequest 的现状。然而，现状仅仅只保持了 data 状态一致，loading、error 的状态并没有保持一致，这就导致多个组件只有在请求成功的场景下才保持状态完全一致，正在请求或请求失败的场景则状态不一定一致，可能出现组件 A 渲染请求成功后的视图，组件 B 却渲染请求失败的视图。

### 👉🏻 Demo 说明
[点击这里查看 codesandbox 示例](https://codesandbox.io/s/ahooks-cache-async-status-53sfdo?file=/src/App.js)

以下以 article1、article2 分别指上下两个 Article 组件实例。
1. 点击 refresh1 按钮
1.1 现状：article1 展示 loading，article2 仍然展示文章内容
1.2 期望：article2 也展示 loading
2. 等待 1s 后
2.1 现状：article1 展示 error，article2 仍然展示文章内容
2.2 期望：article2 也展示 error
3. 点击 refresh2，并等待 1s
3.1 现状：article2 展示更新后的文章内容，article1 仍然展示 error
3.2 期望：article1 也展示更新后的内容

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | useRequest: sync loading and error status across components when cache data valid |
| 🇨🇳 中文 | useRequest: 当使用缓存时，支持跨组件同步 loading 和 error 状态 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供（仍然使用现有的「缓存 & SWR - 数据共享」示例，reviewer 也可以使用该示例查看 PR 效果）
- [x] TypeScript 定义无须补充
- [x] Changelog 已提供