### PR TITLE
perf(createUseStorageState): remove optional chaining

### DIFF
--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -35,15 +35,15 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
     }
 
     const serializer = (value: T) => {
-      if (options?.serializer) {
-        return options?.serializer(value);
+      if (options.serializer) {
+        return options.serializer(value);
       }
       return JSON.stringify(value);
     };
 
     const deserializer = (value: string): T => {
-      if (options?.deserializer) {
-        return options?.deserializer(value);
+      if (options.deserializer) {
+        return options.deserializer(value);
       }
       return JSON.parse(value);
     };
@@ -57,10 +57,10 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
       } catch (e) {
         onError(e);
       }
-      if (isFunction(options?.defaultValue)) {
-        return options?.defaultValue();
+      if (isFunction(options.defaultValue)) {
+        return options.defaultValue();
       }
-      return options?.defaultValue;
+      return options.defaultValue;
     }
 
     const [state, setState] = useState(() => getStoredValue());


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [x] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

`options`有默认值 `{}`，并且在代码28行进行了`解构`。所以后面使用`options`时不需要`?.` (像`useCookieState`中那样)

![img](https://img-blog.csdnimg.cn/18796dcf43dd468bab7f7e3b11e15965.jpeg)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Remove optional chaining  in the `createUseStorageState` code    |
| 🇨🇳 Chinese |     去除`createUseStorageState`中操作`options`时的可选链运算符      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
