### PR TITLE
perf(useLockFn): ensure the stability of the output function reference

### DIFF
--- a/packages/hooks/src/useLockFn/index.ts
+++ b/packages/hooks/src/useLockFn/index.ts
@@ -1,23 +1,20 @@
 import { useRef, useCallback } from 'react';
-
+import useMemoizedFn from '../useMemoizedFn';
 function useLockFn<P extends any[] = any[], V extends any = any>(fn: (...args: P) => Promise<V>) {
   const lockRef = useRef(false);
 
-  return useCallback(
-    async (...args: P) => {
-      if (lockRef.current) return;
-      lockRef.current = true;
-      try {
-        const ret = await fn(...args);
-        lockRef.current = false;
-        return ret;
-      } catch (e) {
-        lockRef.current = false;
-        throw e;
-      }
-    },
-    [fn],
-  );
+  return useMemoizedFn(async (...args: P) => {
+    if (lockRef.current) return;
+    lockRef.current = true;
+    try {
+      const ret = await fn(...args);
+      lockRef.current = false;
+      return ret;
+    } catch (e) {
+      lockRef.current = false;
+      throw e;
+    }
+  });
 }
 
 export default useLockFn;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
resolve: https://github.com/alibaba/hooks/issues/2269
### 💡 需求背景和解决方案
问题：
ahooks 函数处理规范中第一条：[ahooks 所有的输出函数，地址都是不会变化的](https://ahooks.js.org/zh-CN/guide/blog/function)。但是useLockFn实现的输出函数用的是useCallback，会随着入参函数的改变，输出函数地址也改变。
解决：
用useMemoizedFn替换useCallback包裹输出函数。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供