### PR TITLE
fix(useInfiniteScroll): compatibility issues of getScrollTop in Android browsers

### DIFF
--- a/packages/hooks/src/utils/rect.ts
+++ b/packages/hooks/src/utils/rect.ts
@@ -1,5 +1,5 @@
 const getScrollTop = (el: Document | Element) => {
-  if (el === document|| el === document.documentElement || el === document.body) {
+  if (el === document || el === document.documentElement || el === document.body) {
     return Math.max(
       window.pageYOffset,
       document.documentElement.scrollTop,

--- a/packages/hooks/src/utils/rect.ts
+++ b/packages/hooks/src/utils/rect.ts
@@ -1,5 +1,5 @@
 const getScrollTop = (el: Document | Element) => {
-  if (el === document || el === document.body) {
+  if (el === document|| el === document.documentElement || el === document.body) {
     return Math.max(
       window.pageYOffset,
       document.documentElement.scrollTop,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

resolve: [#2283 ](https://github.com/alibaba/hooks/issues/2283)

### 💡 Background and solution
Compatibility issues with Android browsers，document.documentElement.scrollTop return 0
<img width="537" alt="316bd65-eaf9-4441-a285-4c346e5bd001" src="https://github.com/alibaba/hooks/assets/12826705/26ccec64-9b67-44b4-a85c-92a33eeddca4">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix(useInfiniteScroll): compatibility issues of getScrollTop in Android browsers   |
| 🇨🇳 Chinese |    fix(useInfiniteScroll): getScrollTop 在安卓浏览器中的兼容性问题    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
