### PR TITLE
feat(useInfiniteScroll): using useInfiniteScroll with isInverse prop

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/__tests__/index.test.ts
+++ b/packages/hooks/src/useInfiniteScroll/__tests__/index.test.ts
@@ -17,8 +17,6 @@ export async function mockRequest() {
   };
 }
 
-const targetEl = document.createElement('div');
-
 const setup = <T extends Data>(service: Service<T>, options?: InfiniteScrollOptions<T>) =>
   renderHook(() => useInfiniteScroll(service, options));
 
@@ -76,6 +74,7 @@ describe('useInfiniteScroll', () => {
   });
 
   it('should auto load when scroll to bottom', async () => {
+    const targetEl = document.createElement('div');
     const events = {};
     const mockAddEventListener = jest
       .spyOn(targetEl, 'addEventListener')
@@ -126,6 +125,7 @@ describe('useInfiniteScroll', () => {
   });
 
   it('should auto load when scroll to top', async () => {
+    const targetEl = document.createElement('div');
     const events = {};
     const mockAddEventListener = jest
       .spyOn(targetEl, 'addEventListener')

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -99,8 +99,9 @@ const useInfiniteScroll = <TData extends Data>(
     const scrollTop = getScrollTop(el);
     const scrollHeight = getScrollHeight(el);
     const clientHeight = getClientHeight(el);
-    const isReachToBottom = scrollHeight - scrollTop <= clientHeight + threshold;
-    const isReachToTop = scrollTop + scrollHeight <= clientHeight + threshold;
+    const scrollBoundary = clientHeight + threshold;
+    const isReachToBottom = scrollHeight - scrollTop <= scrollBoundary;
+    const isReachToTop = scrollTop + scrollHeight <= scrollBoundary;
     const isReachBoundary = isInverse ? isReachToTop : isReachToBottom;
     if (isReachBoundary) {
       loadMore();

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -99,10 +99,12 @@ const useInfiniteScroll = <TData extends Data>(
     const scrollTop = getScrollTop(el);
     const scrollHeight = getScrollHeight(el);
     const clientHeight = getClientHeight(el);
+
     const scrollBoundary = clientHeight + threshold;
     const isReachToBottom = scrollHeight - scrollTop <= scrollBoundary;
     const isReachToTop = scrollTop + scrollHeight <= scrollBoundary;
     const isReachBoundary = isInverse ? isReachToTop : isReachToBottom;
+
     if (isReachBoundary) {
       loadMore();
     }

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -16,6 +16,7 @@ const useInfiniteScroll = <TData extends Data>(
     isNoMore,
     threshold = 100,
     reloadDeps = [],
+    isInverse,
     manual,
     onBefore,
     onSuccess,
@@ -98,8 +99,10 @@ const useInfiniteScroll = <TData extends Data>(
     const scrollTop = getScrollTop(el);
     const scrollHeight = getScrollHeight(el);
     const clientHeight = getClientHeight(el);
-
-    if (scrollHeight - scrollTop <= clientHeight + threshold) {
+    const isScrollDown = scrollHeight - scrollTop <= clientHeight + threshold;
+    const isScrollUp = scrollTop + scrollHeight <= clientHeight + threshold;
+    const condition = isInverse ? isScrollUp : isScrollDown;
+    if (condition) {
       loadMore();
     }
   };

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -99,10 +99,10 @@ const useInfiniteScroll = <TData extends Data>(
     const scrollTop = getScrollTop(el);
     const scrollHeight = getScrollHeight(el);
     const clientHeight = getClientHeight(el);
-    const isScrollDown = scrollHeight - scrollTop <= clientHeight + threshold;
-    const isScrollUp = scrollTop + scrollHeight <= clientHeight + threshold;
-    const condition = isInverse ? isScrollUp : isScrollDown;
-    if (condition) {
+    const isReachToBottom = scrollHeight - scrollTop <= clientHeight + threshold;
+    const isReachToTop = scrollTop + scrollHeight <= clientHeight + threshold;
+    const isReachBoundary = isInverse ? isReachToTop : isReachToBottom;
+    if (isReachBoundary) {
       loadMore();
     }
   };

--- a/packages/hooks/src/useInfiniteScroll/types.ts
+++ b/packages/hooks/src/useInfiniteScroll/types.ts
@@ -23,7 +23,7 @@ export interface InfiniteScrollOptions<TData extends Data> {
   target?: BasicTarget<Element | Document>;
   isNoMore?: (data?: TData) => boolean;
   threshold?: number;
-
+  isInverse?: boolean;
   manual?: boolean;
   reloadDeps?: DependencyList;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

First and foremost, I want to express my deep appreciation for the ahooks project. It has been an invaluable addition to the React ecosystem, providing a collection of useful hooks that have played a significant role in helping the React community thrive.

### 💡 Background and solution
#### Problem and Scenario:

I've submitted this pull request to tackle a common challenge when implementing chat-like interfaces, where users often need to scroll upwards to load more messages or content. The problem arises because there is currently no built-in functionality to change the scroll direction and trigger the loading function.

Currently, without any props to modify the scroll direction, users must rotate the list and apply CSS tricks to simulate an upward scroll. This workaround is not intuitive and can lead to suboptimal user experiences.

#### Solution:
To improve this situation, I would suggest adding the capability to trigger the loading function when scrolling up, which aligns with common chat application behavior. I've implemented a straightforward logic to achieve this:

When a user scrolls up, the scrollTop value becomes negative relative to the container we monitor for scroll events.
If the sum of the negative scrollTop and the scroll height is less than or equal to the client height, and the chosen threshold is met, we can conclude that the user has scrolled to the top of the page.
At this point, we can trigger the load function, ensuring a smooth and familiar experience for users.

#### Final API Implementation:

As part of this pull request, I've introduced a new prop called isInverse to the useInfiniteScroll hook. When set to true, this prop specifies that the desired scroll direction should be upward. This allows developers to easily configure the scroll behavior to align with common chat application requirements, where users scroll up to load more messages or content.

```
import { useInfiniteScroll } from 'ahooks';
const loadMoreData = () => {
  // Your load more data logic here
};

const { data, loading, loadMore } = useInfiniteScroll({
  isInverse: true, // Specify that the scroll direction should be upward
  loadMore: loadMoreData
});
```

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
