### PR TITLE
fix(createUseStorageState): fix type of returned undefined value

### DIFF
--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -13,6 +13,14 @@ export interface Options<T> {
 }
 
 export function createUseStorageState(getStorage: () => Storage | undefined) {
+  function useStorageState<T>(
+    key: string,
+    options: Options<T> & { defaultValue: T | (() => T) },
+  ): [T, (value?: SetState<T>) => void];
+  function useStorageState<T>(
+    key: string,
+    options?: Options<T>,
+  ): [T | undefined, (value?: SetState<T>) => void];
   function useStorageState<T>(key: string, options: Options<T> = {}) {
     let storage: Storage | undefined;
     const {


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

fix: https://github.com/alibaba/hooks/issues/2202

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

If `createUseStorageState` passes `defaultValue` as an option, I think the state of the 0th element of the array in the return value of `createUseStorageState` will not be `undefined`.

However, since the type information is currently `T | undefined`, the type should be `T` when `defaultValue` is passed as an option for `createUseStorageState`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
