### PR TITLE
feat: 增加usePublisherState Hook

### DIFF
--- a/config/hooks.ts
+++ b/config/hooks.ts
@@ -56,6 +56,7 @@ export const menus = [
       'useSafeState',
       'useGetState',
       'useResetState',
+      'usePublisherState',
     ],
   },
   {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -75,6 +75,7 @@ import useVirtualList from './useVirtualList';
 import useWebSocket from './useWebSocket';
 import useWhyDidYouUpdate from './useWhyDidYouUpdate';
 import useMutationObserver from './useMutationObserver';
+import { usePublisherState, useSubscriberState, PublisherStateType } from './usePublisherState';
 
 export {
   useRequest,
@@ -156,4 +157,7 @@ export {
   useRafTimeout,
   useResetState,
   useMutationObserver,
+  usePublisherState,
+  useSubscriberState,
+  PublisherStateType,
 };

--- a/packages/hooks/src/usePublisherState/__tests__/index.test.ts
+++ b/packages/hooks/src/usePublisherState/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePublisherState, useSubscriberState } from '../index';
+
+describe('usePublisherState', () => {
+  it('should work', () => {
+    const { result } = renderHook(() => usePublisherState(0));
+    const { result: subscriberResult } = renderHook(() => useSubscriberState(result.current[0]));
+    const setRafState = result.current[1];
+    expect(result.current[0].current).toBe(0);
+    expect(subscriberResult.current).toBe(0);
+
+    act(() => {
+      setRafState(1);
+    });
+    expect(result.current[0].current).toBe(1);
+    expect(subscriberResult.current).toBe(1);
+  });
+});

--- a/packages/hooks/src/usePublisherState/demo/demo1.tsx
+++ b/packages/hooks/src/usePublisherState/demo/demo1.tsx
@@ -1,0 +1,47 @@
+/**
+ * title: Default usage
+ *
+ * title.zh-CN: 基础用法
+ */
+
+import { usePublisherState, useSubscriberState } from 'ahooks';
+import type { PublisherStateType } from 'ahooks';
+import React, { useState } from 'react';
+const InnerComp: React.FC<{ data: PublisherStateType<number>; data1: number }> = ({
+  data,
+  data1,
+}) => {
+  const counter = useSubscriberState(data);
+  return (
+    <div>
+      <p>
+        Child counter: {counter},{data1}
+      </p>
+    </div>
+  );
+};
+export default () => {
+  const [counter, setCounter] = usePublisherState(0);
+  const [counter1, setCounter1] = useState(0);
+  return (
+    <div>
+      <p>
+        <button
+          type="button"
+          onClick={() => setCounter((val) => val + 1)}
+          style={{ margin: '0 16px' }}
+        >
+          counter++ with usePublisherState
+        </button>
+        <button type="button" onClick={() => setCounter1((val) => val + 1)}>
+          counter++ with useState
+        </button>
+      </p>
+
+      <p>
+        Parent counter: {counter.current},{counter1}
+      </p>
+      <InnerComp data={counter} data1={counter1} />
+    </div>
+  );
+};

--- a/packages/hooks/src/usePublisherState/index.en-US.md
+++ b/packages/hooks/src/usePublisherState/index.en-US.md
@@ -1,0 +1,48 @@
+---
+nav:
+  path: /hooks
+---
+
+# usePublisherState
+
+Hooks for managing state using a publish-subscribe method, combined with `useSubscriberState`. Updating the state will only trigger re-rendering of components that actively subscribe to it through `useSubscriberState`.
+
+## Example
+
+### Default usage
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+### usePublisherState
+
+```typescript
+type PublisherStateType<T> = {
+  current: T;
+  observable: Observable<string>;
+};
+type SetPublisherStateType<T> = (newVal: T | ((newVal: T) => T), needUpdate?: boolean) => void;
+
+const [state, setState] = usePublisherState<T>(
+  initialState: T,
+): [PublisherStateType, SetPublisherStateType]
+```
+
+Hooks for defining and managing state using the publish-subscribe method. It returns a tuple containing the current state object and a function to update the state.
+
+- `initialState: T`: The initial value of the state.
+
+### useSubscriberState
+
+```typescript
+const state = useSubscriberState<T>(
+  state: PublisherStateType<T>,
+): T
+```
+
+Hooks for subscribing to state updates using the publish-subscribe method. It returns the current value of the state.
+
+- `state: PublisherStateType<T>`: The state object returned by `usePublisherState`.
+
+Translate this documentation into English.

--- a/packages/hooks/src/usePublisherState/index.ts
+++ b/packages/hooks/src/usePublisherState/index.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+
+type Observer<T> = (value: T) => void;
+
+class Observable<T> {
+  private observers: Observer<T>[] = [];
+
+  subscribe(observer: Observer<T>): void {
+    this.observers.push(observer);
+  }
+
+  unsubscribe(observer: Observer<T>): void {
+    this.observers = this.observers.filter((subscriber) => subscriber !== observer);
+  }
+
+  notify(data: T): void {
+    this.observers.forEach((observer) => observer(data));
+  }
+}
+
+export type PublisherStateType<T> = {
+  current: T;
+  observable: Observable<string>;
+};
+type SetPublisherStateType<T> = (newVal: T | ((newVal: T) => T), needUpdate?: boolean) => void;
+
+export function usePublisherState<T>(initialState: T) {
+  const stateRef = useRef<PublisherStateType<T>>({
+    current: initialState,
+    observable: new Observable<string>(),
+  });
+
+  const setState: SetPublisherStateType<T> = (
+    newVal: T | ((oldVal: T) => T),
+    needUpdate = true,
+  ) => {
+    if (typeof newVal === 'function') {
+      stateRef.current.current = (newVal as (newVal: T) => T)(stateRef.current.current);
+      if (needUpdate) stateRef.current.observable.notify('update');
+    } else if (stateRef.current.current !== newVal) {
+      stateRef.current.current = newVal;
+      if (needUpdate) stateRef.current.observable.notify('update');
+    }
+  };
+
+  return [stateRef.current, setState] as const;
+}
+
+export function useSubscriberState<T>(state?: PublisherStateType<T>) {
+  const [, forceUpdate] = useState({});
+  const update = () => forceUpdate({});
+  useEffect(() => {
+    if (!state) return;
+    const observer: Observer<string> = (info) => {
+      if (info === 'update') update();
+    };
+    state.observable.subscribe(observer);
+
+    return () => {
+      state.observable.unsubscribe(observer);
+    };
+  }, [state]);
+
+  return state?.current;
+}

--- a/packages/hooks/src/usePublisherState/index.zh-CN.md
+++ b/packages/hooks/src/usePublisherState/index.zh-CN.md
@@ -1,0 +1,46 @@
+---
+nav:
+  path: /hooks
+---
+
+# usePublisherState
+
+基于发布订阅的 state 方法的 Hooks，与`useSubscriberState`结合使用。更新 state 时只会触发主动通过`useSubscriberState`接收的组件重渲染。
+
+## 代码演示
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+## API
+
+### usePublisherState
+
+```typescript
+type PublisherStateType<T> = {
+  current: T;
+  observable: Observable<string>;
+};
+type SetPublisherStateType<T> = (newVal: T | ((newVal: T) => T), needUpdate?: boolean) => void;
+
+const [state, setState] = usePublisherState<T>(
+  initialState: T,
+): [PublisherStateType, SetPublisherStateType]
+```
+
+基于发布订阅的 state 方法的 Hooks。用于定义和管理状态。返回一个元组，包含当前状态对象和更新状态的方法。
+
+- `initialState: T`: 初始状态的值。
+
+### useSubscriberState
+
+```typescript
+const state = useSubscriberState<T>(
+  state: PublisherStateType<T>,
+): T
+```
+
+基于发布订阅的 state 方法的 Hooks。用于订阅状态的更新。返回当前状态的值。
+
+- `state: PublisherStateType<T>`: `usePublisherState`返回的状态对象。


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
 基于配置的页面级的组件在前端开发当中越来越普遍（如procomponents），在受控模式下，需要对局部进行更新也需要对重新生成整个配置，导致页面的额外渲染。通过开发基于订阅发布的状态管理办法，在需要更新的局部组件中主动进行订阅，避免页面不必要的重绘。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
# usePublisherState

基于发布订阅的 state 方法的 Hooks，与`useSubscriberState`结合使用。更新 state 时只会触发主动通过`useSubscriberState`接收的组件重渲染。

## 代码演示

### 基础用法
```typescript
import { usePublisherState, useSubscriberState } from 'ahooks';
import type { PublisherStateType } from 'ahooks';
import React, { useState } from 'react';
const InnerComp: React.FC<{ data: PublisherStateType<number>; data1: number }> = ({
  data,
  data1,
}) => {
  const counter = useSubscriberState(data);
  return (
    <div>
      <p>
        Child counter: {counter},{data1}
      </p>
    </div>
  );
};
export default () => {
  const [counter, setCounter] = usePublisherState(0);
  const [counter1, setCounter1] = useState(0);
  return (
    <div>
      <p>
        <button
          type="button"
          onClick={() => setCounter((val) => val + 1)}
          style={{ margin: '0 16px' }}
        >
          counter++ with usePublisherState
        </button>
        <button type="button" onClick={() => setCounter1((val) => val + 1)}>
          counter++ with useState
        </button>
      </p>

      <p>
        Parent counter: {counter.current},{counter1}
      </p>
      <InnerComp data={counter} data1={counter1} />
    </div>
  );
};
```

## API

### usePublisherState

```typescript
type PublisherStateType<T> = {
  current: T;
  observable: Observable<string>;
};
type SetPublisherStateType<T> = (newVal: T | ((newVal: T) => T), needUpdate?: boolean) => void;

const [state, setState] = usePublisherState<T>(
  initialState: T,
): [PublisherStateType, SetPublisherStateType]
```

基于发布订阅的 state 方法的 Hooks。用于定义和管理状态。返回一个元组，包含当前状态对象和更新状态的方法。

- `initialState: T`: 初始状态的值。

### useSubscriberState

```typescript
const state = useSubscriberState<T>(
  state: PublisherStateType<T>,
): T
```

基于发布订阅的 state 方法的 Hooks。用于订阅状态的更新。返回当前状态的值。

- `state: PublisherStateType<T>`: `usePublisherState`返回的状态对象。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供