### PR TITLE
fix(useSize): 修改获取尺寸问题

### DIFF
--- a/packages/hooks/src/useSize/__tests__/index.test.tsx
+++ b/packages/hooks/src/useSize/__tests__/index.test.tsx
@@ -44,7 +44,18 @@ describe('useSize', () => {
     expect(await screen.findByText(/^width/)).toHaveTextContent('width: undefined');
     expect(await screen.findByText(/^height/)).toHaveTextContent('height: undefined');
 
-    act(() => callback([{ target: { clientWidth: 10, clientHeight: 10 } }]));
+    act(() =>
+      callback([
+        {
+          target: {
+            getBoundingClientRect: jest.fn(() => ({
+              width: 10,
+              height: 10,
+            })),
+          },
+        },
+      ]),
+    );
     expect(await screen.findByText(/^width/)).toHaveTextContent('width: 10');
     expect(await screen.findByText(/^height/)).toHaveTextContent('height: 10');
     mockRaf.mockRestore();
@@ -70,8 +81,10 @@ describe('useSize', () => {
       callback([
         {
           target: {
-            clientWidth: 100,
-            clientHeight: 50,
+            getBoundingClientRect: jest.fn(() => ({
+              width: 100,
+              height: 50,
+            })),
           },
         },
       ]);

--- a/packages/hooks/src/useSize/index.ts
+++ b/packages/hooks/src/useSize/index.ts
@@ -7,12 +7,12 @@ import useIsomorphicLayoutEffectWithTarget from '../utils/useIsomorphicLayoutEff
 type Size = { width: number; height: number };
 
 function useSize(target: BasicTarget): Size | undefined {
-  const [state, setState] = useRafState<Size | undefined>(
-    () => {
-      const el = getTargetElement(target);
-      return el ? { width: el.clientWidth, height: el.clientHeight } : undefined
-    },
-  );
+  const [state, setState] = useRafState<Size | undefined>(() => {
+    const el = getTargetElement(target);
+    return el
+      ? { width: el.getBoundingClientRect().width, height: el.getBoundingClientRect().height }
+      : undefined;
+  });
 
   useIsomorphicLayoutEffectWithTarget(
     () => {
@@ -24,8 +24,13 @@ function useSize(target: BasicTarget): Size | undefined {
 
       const resizeObserver = new ResizeObserver((entries) => {
         entries.forEach((entry) => {
-          const { clientWidth, clientHeight } = entry.target;
-          setState({ width: clientWidth, height: clientHeight });
+          // clientWidth: 返回表示元素可见宽度的整数值。
+          // getBoundingClientRect -> width: 元素的真实宽度
+          const { width, height } = (entry.target as HTMLElement)?.getBoundingClientRect() ?? {
+            width: 0,
+            height: 0,
+          };
+          setState({ width, height });
         });
       });
       resizeObserver.observe(el);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

```tsx
const App = () => {
    const ref = useRef(null);
    const width = useSize(ref);
    // console.log(51) error
    return <div style={{fontSize: '12px'}} ref={ref}>前程似锦.</div>
}
```
这里应该获取的实际宽度，而不是可见宽度


