### PR TITLE
feat(useRequest): add parameters trigger to the options[onBefore],add skipStaleTime in refreshOptions

### DIFF
--- a/packages/hooks/src/useRequest/__tests__/index.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
+import { Trigger } from '../src/types';
 
 const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -201,5 +202,49 @@ describe('useRequest', () => {
     await waitFor(() => expect(hook.result.current.data).toBe('success'));
     expect(hook.result.current.loading).toBe(false);
     hook.unmount();
+  });
+
+  it('useRequest trigger should return in onBefore, trigger should be correct', async () => {
+    let triggerValue;
+    const beforeCallback = (_, trigger) => {
+      triggerValue = trigger;
+    };
+    act(() => {
+      hook = setUp(request, {
+        onBefore: beforeCallback,
+      });
+    });
+    expect(triggerValue).toBe(Trigger.AUTO);
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      hook.result.current.run();
+    });
+    expect(triggerValue).toBe(Trigger.RUN);
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      hook.result.current.runAsync();
+    });
+    expect(triggerValue).toBe(Trigger.RUN_ASYNC);
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      hook.result.current.refresh();
+    });
+    expect(triggerValue).toBe(Trigger.REFRESH);
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      hook.result.current.refreshAsync();
+    });
+    expect(triggerValue).toBe(Trigger.REFRESH_ASYNC);
+    act(() => {
+      jest.runAllTimers();
+    });
   });
 });

--- a/packages/hooks/src/useRequest/__tests__/useAutoRunPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useAutoRunPlugin.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
+import { Trigger } from '../src/types';
 
 describe('useAutoRunPlugin', () => {
   jest.useFakeTimers();
@@ -9,13 +10,19 @@ describe('useAutoRunPlugin', () => {
 
   let hook;
 
-  it('useAutoRunPlugin ready should work', async () => {
-    let dep = 1;
+  it('useAutoRunPlugin ready should work, trigger should be correct', async () => {
+    let dep = 1,
+      triggerValue;
+    const beforeCallback = (_, trigger) => {
+      triggerValue = trigger;
+    };
     act(() => {
       hook = setUp(request, {
         refreshDeps: [dep],
+        onBefore: beforeCallback,
       });
     });
+    expect(triggerValue).toBe(Trigger.AUTO);
     expect(hook.result.current.loading).toBe(true);
 
     act(() => {
@@ -26,7 +33,9 @@ describe('useAutoRunPlugin', () => {
     dep = 2;
     hook.rerender({
       refreshDeps: [dep],
+      onBefore: beforeCallback,
     });
+    expect(triggerValue).toBe(Trigger.REFRESH_DEPS);
     expect(hook.result.current.loading).toBe(true);
 
     act(() => {
@@ -36,7 +45,10 @@ describe('useAutoRunPlugin', () => {
 
     hook.rerender({
       refreshDeps: [dep],
+      onBefore: beforeCallback,
     });
+    // 不会改变
+    expect(triggerValue).toBe(Trigger.REFRESH_DEPS);
     expect(hook.result.current.loading).toBe(false);
   });
 

--- a/packages/hooks/src/useRequest/__tests__/useCachePlugin.test.tsx
+++ b/packages/hooks/src/useRequest/__tests__/useCachePlugin.test.tsx
@@ -70,6 +70,41 @@ describe('useCachePlugin', () => {
     expect(hook3.result.current.loading).toBe(false);
   });
 
+  it('useRequest skipStaleTime should work', async () => {
+    await testCacheKey({
+      cacheKey: 'testSkipStaleTime',
+      staleTime: 3000,
+    });
+    jest.advanceTimersByTime(1000);
+    const hook2 = setup(request, {
+      cacheKey: 'testSkipStaleTime',
+      staleTime: 3000,
+    });
+    act(() => {
+      hook2.result.current.refresh();
+    });
+    expect(hook2.result.current.loading).toBe(false);
+    expect(hook2.result.current.data).toBe('success');
+    act(() => {
+      hook2.result.current.refresh({
+        skipStaleTime: true,
+      });
+    });
+    expect(hook2.result.current.loading).toBe(true);
+    await waitFor(() => expect(hook2.result.current.data).toBe('success'));
+    act(() => {
+      hook2.result.current.refresh();
+    });
+    expect(hook2.result.current.loading).toBe(false);
+    act(() => {
+      hook2.result.current.refresh({
+        skipStaleTime: true,
+      });
+    });
+    expect(hook2.result.current.loading).toBe(true);
+    hook2.unmount();
+  });
+
   it('useRequest cacheTime should work', async () => {
     await testCacheKey({
       cacheKey: 'testCacheTime',

--- a/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
+import { Trigger } from '../src/types';
 
 describe('usePollingPlugin', () => {
   jest.useFakeTimers();
@@ -65,20 +66,24 @@ describe('usePollingPlugin', () => {
   });
 
   let hook2;
-  it('usePollingPlugin pollingErrorRetryCount=3 should work', async () => {
+  it('usePollingPlugin pollingErrorRetryCount=3 should work, trigger should be correct', async () => {
     // if request error and set pollingErrorRetryCount
     // and the number of consecutive failures exceeds pollingErrorRetryCount, polling stops
-    let errorCallback;
+    let errorCallback, triggerValue;
+    const beforeCallback = (_, trigger) => {
+      triggerValue = trigger;
+    };
     act(() => {
       errorCallback = jest.fn();
       hook2 = setUp(() => request(0), {
         pollingErrorRetryCount: 3,
         pollingInterval: 100,
         pollingWhenHidden: true,
+        onBefore: beforeCallback,
         onError: errorCallback,
       });
     });
-
+    expect(triggerValue).toBe(Trigger.AUTO);
     expect(hook2.result.current.loading).toBe(true);
     expect(errorCallback).toHaveBeenCalledTimes(0);
 
@@ -91,26 +96,39 @@ describe('usePollingPlugin', () => {
     act(() => {
       jest.runAllTimers();
     });
+
+    expect(triggerValue).toBe(Trigger.POLLING);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(2));
 
     act(() => {
       jest.runAllTimers();
     });
+
+    expect(triggerValue).toBe(Trigger.POLLING);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(3));
 
     act(() => {
       jest.runAllTimers();
     });
+
+    expect(triggerValue).toBe(Trigger.POLLING);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(4));
 
     act(() => {
       jest.runAllTimers();
     });
+
+    expect(triggerValue).toBe(Trigger.POLLING);
+
     expect(errorCallback).toHaveBeenCalledTimes(4);
 
     act(() => {
       hook2.result.current.run();
     });
+    expect(triggerValue).toBe(Trigger.RUN);
     act(() => {
       jest.runAllTimers();
     });

--- a/packages/hooks/src/useRequest/__tests__/useRefreshOnWindowFocusPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useRefreshOnWindowFocusPlugin.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
+import { Trigger } from '../src/types';
 
 describe('useRefreshOnWindowFocusPlugin', () => {
   jest.useFakeTimers();
@@ -9,10 +10,15 @@ describe('useRefreshOnWindowFocusPlugin', () => {
   const setUp = (service, options) => renderHook((o) => useRequest(service, o || options));
 
   let hook;
-  it('useRefreshOnWindowFocusPlugin should work', async () => {
+  it('useRefreshOnWindowFocusPlugin should work, trigger should be correct', async () => {
+    let triggerValue;
+    const beforeCallback = (_, trigger) => {
+      triggerValue = trigger;
+    };
     act(() => {
       hook = setUp(request, {
         refreshOnWindowFocus: true,
+        onBefore: beforeCallback,
         focusTimespan: 5000,
       });
     });
@@ -25,7 +31,7 @@ describe('useRefreshOnWindowFocusPlugin', () => {
       fireEvent.focus(window);
     });
     expect(hook.result.current.loading).toBe(true);
-
+    expect(triggerValue).toBe(Trigger.REFRESH_ON_WINDOW_FOCUS);
     act(() => {
       jest.advanceTimersByTime(2000);
     });

--- a/packages/hooks/src/useRequest/__tests__/useRetryPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useRetryPlugin.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
+import { Trigger } from '../src/types';
 
 describe('useRetryPlugin', () => {
   jest.useFakeTimers();
@@ -8,44 +9,53 @@ describe('useRetryPlugin', () => {
   const setUp = (service, options) => renderHook((o) => useRequest(service, o || options));
 
   let hook;
-  it('useRetryPlugin should work', async () => {
-    let errorCallback;
+  it('useRetryPlugin should work, trigger should be correct', async () => {
+    let errorCallback, triggerValue;
+    const beforeCallback = (_, trigger) => {
+      triggerValue = trigger;
+    };
     act(() => {
       errorCallback = jest.fn();
       hook = setUp(() => request(0), {
         retryCount: 3,
+        onBefore: beforeCallback,
         onError: errorCallback,
       });
     });
+    expect(triggerValue).toBe(Trigger.AUTO);
     act(() => {
       jest.setTimeout(10000);
       jest.advanceTimersByTime(500);
     });
     expect(errorCallback).toHaveBeenCalledTimes(0);
-
     act(() => {
       jest.runAllTimers();
     });
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(1));
-
     act(() => {
       jest.runAllTimers();
     });
+    expect(triggerValue).toBe(Trigger.RETRY);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(2));
-
     act(() => {
       jest.runAllTimers();
     });
+    expect(triggerValue).toBe(Trigger.RETRY);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(3));
-
     act(() => {
       jest.runAllTimers();
     });
+    expect(triggerValue).toBe(Trigger.RETRY);
+
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(4));
 
     act(() => {
       jest.runAllTimers();
     });
+    expect(triggerValue).toBe(Trigger.RETRY);
     expect(errorCallback).toHaveBeenCalledTimes(4);
     hook.unmount();
 

--- a/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
@@ -128,7 +128,7 @@ const {
   params: TParams || [],
   run: (...params: TParams) => void,
   runAsync: (...params: TParams) => Promise<TData>,
-  refresh: () => void,
+  refresh: (options?: RefreshOptions) => void,
   refreshAsync: () => Promise<TData>,
   mutate: (data?: TData | ((oldData?: TData) => (TData | undefined))) => void,
   cancel: () => void,
@@ -155,7 +155,7 @@ const {
 | params       | An array of parameters for the service being executed. For example, you triggered `run(1, 2, 3)`, then params is equal to `[1, 2, 3]`                                                   | `TParams` \| `[]`                                                     |
 | run          | <ul><li> Manually trigger the execution of the service, and the parameters will be passed to the service</li><li>Automatic handling of exceptions, feedback through `onError`</li></ul> | `(...params : TParams) => void`                                       |
 | runAsync     | The usage is the same as `run`, but it returns a Promise, so you need to handle the exception yourself.                                                                                 | `(...params: TParams) => Promise<TData>`                              |
-| refresh      | Use the last params, call `run` again                                                                                                                                                   | `() => void`                                                          |
+| refresh      | Use the last params, call `run` again                                                                                                                                                   | `(options?:RefreshOptions) => void`                                   |
 | refreshAsync | Use the last params, call `runAsync` again                                                                                                                                              | `() => Promise<TData>`                                                |
 | mutate       | Mutate `data` directly                                                                                                                                                                  | `(data?: TData / ((oldData?: TData) => (TData / undefined))) => void` |
 | cancel       | Ignore the current promise response                                                                                                                                                     | `() => void`                                                          |
@@ -170,6 +170,12 @@ const {
 | onSuccess     | Triggered when service resolve                                                                                                                                                                                   | `(data: TData, params: TParams) => void`             | -       |
 | onError       | Triggered when service reject                                                                                                                                                                                    | `(e: Error, params: TParams) => void`                | -       |
 | onFinally     | Triggered when service execution is complete                                                                                                                                                                     | `(params: TParams, data?: TData, e?: Error) => void` | -       |
+
+### RefreshOptions
+
+| 参数          | 说明             | 类型      | 默认值  |
+| ------------- | ---------------- | --------- | ------- |
+| skipStaleTime | skip `staleTime` | `boolean` | `false` |
 
 ### Trigger
 

--- a/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
@@ -137,7 +137,7 @@ const {
   {
     manual?: boolean,
     defaultParams?: TParams,
-    onBefore?: (params: TParams) => void,
+    onBefore?: (params: TParams, trigget: Trigger) => void,
     onSuccess?: (data: TData, params: TParams) => void,
     onError?: (e: Error, params: TParams) => void,
     onFinally?: (params: TParams, data?: TData, e?: Error) => void,
@@ -166,9 +166,23 @@ const {
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------- |
 | manual        | <ul><li> The default is `false`. That is, the service is automatically executed during initialization. </li><li>If set to `true`, you need to manually call `run` or `runAsync` to trigger execution. </li></ul> | `boolean`                                            | `false` |
 | defaultParams | The parameters passed to the service at the first default execution                                                                                                                                              | `TParams`                                            | -       |
-| onBefore      | Triggered before service execution                                                                                                                                                                               | `(params: TParams) => void`                          | -       |
+| onBefore      | Triggered before service execution                                                                                                                                                                               | `(params: TParams, trigget: Trigger) => void`        | -       |
 | onSuccess     | Triggered when service resolve                                                                                                                                                                                   | `(data: TData, params: TParams) => void`             | -       |
 | onError       | Triggered when service reject                                                                                                                                                                                    | `(e: Error, params: TParams) => void`                | -       |
 | onFinally     | Triggered when service execution is complete                                                                                                                                                                     | `(params: TParams, data?: TData, e?: Error) => void` | -       |
+
+### Trigger
+
+| EnumValue               | Description               |
+| ----------------------- | ------------------------- |
+| AUTO                    | From first time auto run  |
+| RUN                     | Call `run`                |
+| RUN_ASYNC               | Call `runAsync`           |
+| REFRESH                 | Call `refresh`            |
+| REFRESH_ASYNC           | Call `refreshAsync`       |
+| POLLING                 | From polling              |
+| REFRESH_DEPS            | From refreshDeps          |
+| REFRESH_ON_WINDOW_FOCUS | From refreshOnWindowFocus |
+| RETRY                   | From retry                |
 
 Above we have introduced the most basic functionalities of useRequest, and then we will introduce some more advanced functionalities.

--- a/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
@@ -128,7 +128,7 @@ const {
   params: TParams || [],
   run: (...params: TParams) => void,
   runAsync: (...params: TParams) => Promise<TData>,
-  refresh: () => void,
+  refresh: (options?: RefreshOptions) => void,
   refreshAsync: () => Promise<TData>,
   mutate: (data?: TData | ((oldData?: TData) => (TData | undefined))) => void,
   cancel: () => void,
@@ -155,7 +155,7 @@ const {
 | params       | 当次执行的 service 的参数数组。比如你触发了 `run(1, 2, 3)`，则 params 等于 `[1, 2, 3]`                   | `TParams` \| `[]`                                                     |
 | run          | <ul><li> 手动触发 service 执行，参数会传递给 service</li><li>异常自动处理，通过 `onError` 反馈</li></ul> | `(...params: TParams) => void`                                        |
 | runAsync     | 与 `run` 用法一致，但返回的是 Promise，需要自行处理异常。                                                | `(...params: TParams) => Promise<TData>`                              |
-| refresh      | 使用上一次的 params，重新调用 `run`                                                                      | `() => void`                                                          |
+| refresh      | 使用上一次的 params，重新调用 `run`                                                                      | `(options?:RefreshOptions) => void`                                   |
 | refreshAsync | 使用上一次的 params，重新调用 `runAsync`                                                                 | `() => Promise<TData>`                                                |
 | mutate       | 直接修改 `data`                                                                                          | `(data?: TData / ((oldData?: TData) => (TData / undefined))) => void` |
 | cancel       | 忽略当前 Promise 的响应                                                                                  | `() => void`                                                          |
@@ -170,6 +170,12 @@ const {
 | onSuccess     | service resolve 时触发                                                                                                                     | `(data: TData, params: TParams) => void`             | -       |
 | onError       | service reject 时触发                                                                                                                      | `(e: Error, params: TParams) => void`                | -       |
 | onFinally     | service 执行完成时触发                                                                                                                     | `(params: TParams, data?: TData, e?: Error) => void` | -       |
+
+### RefreshOptions
+
+| 参数          | 说明           | 类型      | 默认值  |
+| ------------- | -------------- | --------- | ------- |
+| skipStaleTime | 跳过 staleTime | `boolean` | `false` |
 
 ### Trigger
 

--- a/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
@@ -137,7 +137,7 @@ const {
   {
     manual?: boolean,
     defaultParams?: TParams,
-    onBefore?: (params: TParams) => void,
+    onBefore?: (params: TParams, trigget: Trigger) => void,
     onSuccess?: (data: TData, params: TParams) => void,
     onError?: (e: Error, params: TParams) => void,
     onFinally?: (params: TParams, data?: TData, e?: Error) => void,
@@ -166,9 +166,23 @@ const {
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | ------- |
 | manual        | <ul><li> 默认 `false`。 即在初始化时自动执行 service。</li><li>如果设置为 `true`，则需要手动调用 `run` 或 `runAsync` 触发执行。 </li></ul> | `boolean`                                            | `false` |
 | defaultParams | 首次默认执行时，传递给 service 的参数                                                                                                      | `TParams`                                            | -       |
-| onBefore      | service 执行前触发                                                                                                                         | `(params: TParams) => void`                          | -       |
+| onBefore      | service 执行前触发                                                                                                                         | `(params: TParams, trigget: Trigger) => void`        | -       |
 | onSuccess     | service resolve 时触发                                                                                                                     | `(data: TData, params: TParams) => void`             | -       |
 | onError       | service reject 时触发                                                                                                                      | `(e: Error, params: TParams) => void`                | -       |
 | onFinally     | service 执行完成时触发                                                                                                                     | `(params: TParams, data?: TData, e?: Error) => void` | -       |
+
+### Trigger
+
+| 枚举值                  | 说明                 |
+| ----------------------- | -------------------- |
+| AUTO                    | 首次自动触发         |
+| RUN                     | 调用`run`            |
+| RUN_ASYNC               | 调用`runAsync`       |
+| REFRESH                 | 调用`refresh`        |
+| REFRESH_ASYNC           | 调用`refreshAsync`   |
+| POLLING                 | 来自轮询             |
+| REFRESH_DEPS            | 来自依赖变更         |
+| REFRESH_ON_WINDOW_FOCUS | 来自屏幕聚焦重新请求 |
+| RETRY                   | 来自错误重试         |
 
 以上我们介绍了 useRequest 最基础的功能，接下来我们介绍一些更高级的能力。

--- a/packages/hooks/src/useRequest/doc/basic/demo/lifeCycle.tsx
+++ b/packages/hooks/src/useRequest/doc/basic/demo/lifeCycle.tsx
@@ -17,7 +17,7 @@ function editUsername(username: string): Promise<void> {
 export default () => {
   const [state, setState] = useState('');
 
-  const { loading, run, refresh, refreshAsync } = useRequest(editUsername, {
+  const { loading, run, refresh } = useRequest(editUsername, {
     manual: true,
     onBefore: (params, trigger) => {
       message.info(`${trigger} :Start Request: ${params[0]}`);
@@ -45,7 +45,7 @@ export default () => {
       <button disabled={loading} type="button" onClick={() => run(state)}>
         {loading ? 'Loading' : 'Edit'}
       </button>
-      <button disabled={loading} type="button" onClick={refresh}>
+      <button disabled={loading} type="button" onClick={() => refresh()} style={{ marginLeft: 16 }}>
         refresh
       </button>
     </div>

--- a/packages/hooks/src/useRequest/doc/basic/demo/lifeCycle.tsx
+++ b/packages/hooks/src/useRequest/doc/basic/demo/lifeCycle.tsx
@@ -17,10 +17,10 @@ function editUsername(username: string): Promise<void> {
 export default () => {
   const [state, setState] = useState('');
 
-  const { loading, run } = useRequest(editUsername, {
+  const { loading, run, refresh, refreshAsync } = useRequest(editUsername, {
     manual: true,
-    onBefore: (params) => {
-      message.info(`Start Request: ${params[0]}`);
+    onBefore: (params, trigger) => {
+      message.info(`${trigger} :Start Request: ${params[0]}`);
     },
     onSuccess: (result, params) => {
       setState('');
@@ -44,6 +44,9 @@ export default () => {
       />
       <button disabled={loading} type="button" onClick={() => run(state)}>
         {loading ? 'Loading' : 'Edit'}
+      </button>
+      <button disabled={loading} type="button" onClick={refresh}>
+        refresh
       </button>
     </div>
   );

--- a/packages/hooks/src/useRequest/doc/basic/demo/refresh.tsx
+++ b/packages/hooks/src/useRequest/doc/basic/demo/refresh.tsx
@@ -32,7 +32,7 @@ export default () => {
   return (
     <div>
       <p>Username: {data}</p>
-      <button onClick={refresh} type="button">
+      <button onClick={() => refresh()} type="button">
         Refresh
       </button>
     </div>

--- a/packages/hooks/src/useRequest/doc/cache/cache.en-US.md
+++ b/packages/hooks/src/useRequest/doc/cache/cache.en-US.md
@@ -25,6 +25,7 @@ In the following example, we set the `cacheKey`. When the component is loaded fo
 
 By setting `staleTime`, we can specify the data retention time, during which time the request will not be re-run. The following example sets a fresh time of 5s, you can experience the effect by clicking the button
 
+When you need to force new data, you can configure `skipStaleTime` to `true` in `refresh`, which will skip `staleTime` to refresh
 <code src="./demo/staleTime.tsx" />
 
 ### Data sharing

--- a/packages/hooks/src/useRequest/doc/cache/cache.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/cache/cache.zh-CN.md
@@ -25,6 +25,8 @@ group:
 
 通过设置 `staleTime`，我们可以指定数据新鲜时间，在这个时间内，不会重新发起请求。下面的示例设置了 5s 的新鲜时间，你可以通过点击按钮来体验效果
 
+当你需要强制获取新数据时可以在 `refresh` 中配置 `skipStaleTime` 为 `true`,将跳过 `staleTime` 进行刷新
+
 <code src="./demo/staleTime.tsx" />
 
 ### 数据共享

--- a/packages/hooks/src/useRequest/doc/cache/demo/staleTime.tsx
+++ b/packages/hooks/src/useRequest/doc/cache/demo/staleTime.tsx
@@ -16,7 +16,7 @@ async function getArticle(): Promise<{ data: string; time: number }> {
 }
 
 const Article = () => {
-  const { data, loading } = useRequest(getArticle, {
+  const { data, loading, refresh } = useRequest(getArticle, {
     cacheKey: 'staleTime-demo',
     staleTime: 5000,
   });
@@ -25,6 +25,21 @@ const Article = () => {
   }
   return (
     <>
+      <br />
+      <button type="button" onClick={() => refresh()}>
+        refresh
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          refresh({
+            skipStaleTime: true,
+          })
+        }
+        style={{ marginLeft: '10px' }}
+      >
+        refresh:skipStaleTime
+      </button>
       <p>Background loading: {loading ? 'true' : 'false'}</p>
       <p>Latest request time: {data?.time}</p>
       <p>{data?.data}</p>
@@ -36,7 +51,7 @@ export default () => {
   const [state, { toggle }] = useBoolean();
   return (
     <div>
-      <button type="button" onClick={() => toggle()}>
+      <button type="button" style={{ marginBottom: '10px' }} onClick={() => toggle()}>
         show/hidden
       </button>
       {state && <Article />}

--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -11,7 +11,7 @@ import type {
   TempConfig,
 } from './types';
 import { Trigger } from './types';
-import { omit } from 'lodash-es';
+import { pick, keys } from 'lodash-es';
 
 const getDefaultTempConfig: () => TempConfig = () => ({
   trigger: undefined,
@@ -56,7 +56,10 @@ export default class Fetch<TData, TParams extends any[]> {
     this.tempConfig = {
       ...this.tempConfig,
       // 不允许修改触发器类型
-      ...omit(config, 'trigger'),
+      ...pick(
+        config,
+        keys(getDefaultTempConfig()).filter((key) => key !== 'trigger'),
+      ),
     };
   }
   getTempConfig(key: keyof TempConfig | undefined) {

--- a/packages/hooks/src/useRequest/src/plugins/useAutoRunPlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useAutoRunPlugin.ts
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import useUpdateEffect from '../../../useUpdateEffect';
 import type { Plugin } from '../types';
+import { Trigger } from '../types';
 
 // support refreshDeps & ready
 const useAutoRunPlugin: Plugin<any, any[]> = (
@@ -13,6 +14,7 @@ const useAutoRunPlugin: Plugin<any, any[]> = (
   useUpdateEffect(() => {
     if (!manual && ready) {
       hasAutoRun.current = true;
+      fetchInstance.setTrigger(Trigger.AUTO);
       fetchInstance.run(...defaultParams);
     }
   }, [ready]);
@@ -26,6 +28,7 @@ const useAutoRunPlugin: Plugin<any, any[]> = (
       if (refreshDepsAction) {
         refreshDepsAction();
       } else {
+        fetchInstance.setTrigger(Trigger.REFRESH_DEPS);
         fetchInstance.refresh();
       }
     }

--- a/packages/hooks/src/useRequest/src/plugins/usePollingPlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/usePollingPlugin.ts
@@ -3,6 +3,7 @@ import useUpdateEffect from '../../../useUpdateEffect';
 import type { Plugin, Timeout } from '../types';
 import isDocumentVisible from '../utils/isDocumentVisible';
 import subscribeReVisible from '../utils/subscribeReVisible';
+import { Trigger } from '../types';
 
 const usePollingPlugin: Plugin<any, any[]> = (
   fetchInstance,
@@ -46,6 +47,7 @@ const usePollingPlugin: Plugin<any, any[]> = (
         (pollingErrorRetryCount !== -1 && countRef.current <= pollingErrorRetryCount)
       ) {
         timerRef.current = setTimeout(() => {
+          fetchInstance.setTrigger(Trigger.POLLING);
           // if pollingWhenHidden = false && document is hidden, then stop polling and subscribe revisible
           if (!pollingWhenHidden && !isDocumentVisible()) {
             unsubscribeRef.current = subscribeReVisible(() => {

--- a/packages/hooks/src/useRequest/src/plugins/useRefreshOnWindowFocusPlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useRefreshOnWindowFocusPlugin.ts
@@ -3,7 +3,7 @@ import useUnmount from '../../../useUnmount';
 import type { Plugin } from '../types';
 import limit from '../utils/limit';
 import subscribeFocus from '../utils/subscribeFocus';
-
+import { Trigger } from '../types';
 const useRefreshOnWindowFocusPlugin: Plugin<any, any[]> = (
   fetchInstance,
   { refreshOnWindowFocus, focusTimespan = 5000 },
@@ -18,6 +18,7 @@ const useRefreshOnWindowFocusPlugin: Plugin<any, any[]> = (
     if (refreshOnWindowFocus) {
       const limitRefresh = limit(fetchInstance.refresh.bind(fetchInstance), focusTimespan);
       unsubscribeRef.current = subscribeFocus(() => {
+        fetchInstance.setTrigger(Trigger.REFRESH_ON_WINDOW_FOCUS);
         limitRefresh();
       });
     }

--- a/packages/hooks/src/useRequest/src/plugins/useRetryPlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useRetryPlugin.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import type { Plugin, Timeout } from '../types';
+import { Trigger } from '../types';
 
 const useRetryPlugin: Plugin<any, any[]> = (fetchInstance, { retryInterval, retryCount }) => {
   const timerRef = useRef<Timeout>();
@@ -32,6 +33,7 @@ const useRetryPlugin: Plugin<any, any[]> = (fetchInstance, { retryInterval, retr
         const timeout = retryInterval ?? Math.min(1000 * 2 ** countRef.current, 30000);
         timerRef.current = setTimeout(() => {
           triggerByRetry.current = true;
+          fetchInstance.setTrigger(Trigger.RETRY);
           fetchInstance.refresh();
         }, timeout);
       } else {

--- a/packages/hooks/src/useRequest/src/types.ts
+++ b/packages/hooks/src/useRequest/src/types.ts
@@ -34,7 +34,12 @@ export enum Trigger {
   // 来自重试
   RETRY = 'RETRY',
 }
-
+export interface RefreshOptions {
+  skipStaleTime?: boolean;
+}
+export interface TempConfig extends RefreshOptions {
+  trigger: Trigger | undefined;
+}
 export interface PluginReturn<TData, TParams extends any[]> {
   onBefore?: (params: TParams) =>
     | ({

--- a/packages/hooks/src/useRequest/src/types.ts
+++ b/packages/hooks/src/useRequest/src/types.ts
@@ -14,6 +14,27 @@ export interface FetchState<TData, TParams extends any[]> {
   error?: Error;
 }
 
+export enum Trigger {
+  // 自动触发
+  AUTO = 'AUTO',
+  // 调用run
+  RUN = 'RUN',
+  // 调用runAsync
+  RUN_ASYNC = 'RUN_ASYNC',
+  // 调用refresh
+  REFRESH = 'REFRESH',
+  // 调用refreshAsync
+  REFRESH_ASYNC = 'REFRESH_ASYNC',
+  // 来自轮询
+  POLLING = 'POLLING',
+  // 来自依赖变更
+  REFRESH_DEPS = 'REFRESH_DEPS',
+  // 来自重新聚焦
+  REFRESH_ON_WINDOW_FOCUS = 'REFRESH_ON_WINDOW_FOCUS',
+  // 来自重试
+  RETRY = 'RETRY',
+}
+
 export interface PluginReturn<TData, TParams extends any[]> {
   onBefore?: (params: TParams) =>
     | ({
@@ -41,7 +62,7 @@ export interface PluginReturn<TData, TParams extends any[]> {
 export interface Options<TData, TParams extends any[]> {
   manual?: boolean;
 
-  onBefore?: (params: TParams) => void;
+  onBefore?: (params: TParams, trigger: Trigger | undefined) => void;
   onSuccess?: (data: TData, params: TParams) => void;
   onError?: (e: Error, params: TParams) => void;
   // formatResult?: (res: any) => TData;

--- a/packages/hooks/src/useRequest/src/useRequestImplement.ts
+++ b/packages/hooks/src/useRequest/src/useRequestImplement.ts
@@ -8,6 +8,7 @@ import isDev from '../../utils/isDev';
 
 import Fetch from './Fetch';
 import type { Options, Plugin, Result, Service } from './types';
+import { Trigger } from './types';
 
 function useRequestImplement<TData, TParams extends any[]>(
   service: Service<TData, TParams>,
@@ -49,6 +50,7 @@ function useRequestImplement<TData, TParams extends any[]>(
     if (!manual) {
       // useCachePlugin can set fetchInstance.state.params from cache when init
       const params = fetchInstance.state.params || options.defaultParams || [];
+      fetchInstance.setTrigger(Trigger.AUTO);
       // @ts-ignore
       fetchInstance.run(...params);
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close: https://github.com/alibaba/hooks/issues/2359
close: https://github.com/alibaba/hooks/issues/2354

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
用户可能不知道本次请求来源于哪个触发器，应该在回调中告知用户
请求 useRequest 的 refresh 支持忽略 staleTime
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
使用ts event直接绑定refresh时会提示类型错误
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    add parameters trigger to the options[onBefore],add skipStaleTime in refreshOptions      |
| 🇨🇳 中文 |      在onBefore参数中添加 trigger ,refresh 支持忽略 staleTime  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供