### PR TITLE
perf(useControllableValue): onChange 增加返回值 Promise

### DIFF
--- a/packages/hooks/src/useControllableValue/__tests__/index.test.ts
+++ b/packages/hooks/src/useControllableValue/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import useControllableValue, { Options, Props } from '../index';
+import { sleep } from '../../utils/testingHelpers';
 
 describe('useControllableValue', () => {
   const setUp = (props?: Props, options?: Options<any>): any =>
@@ -36,6 +37,23 @@ describe('useControllableValue', () => {
     });
     expect(props.value).toBe(3);
     expect(extraParam).toBe('extraParam');
+  });
+
+  it('onChange return promise should work', async () => {
+    const props = {
+      value: 2,
+      loading: true,
+      async onChange(val: number) {
+        await sleep(10);
+        this.value = val + 10;
+      },
+    };
+    const hook = setUp(props);
+    expect(hook.result.current[0]).toBe(2);
+    const result = hook.result.current[1](3);
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+    expect(props.value).toBe(13);
   });
 
   it('test on state update', () => {

--- a/packages/hooks/src/useControllableValue/index.ts
+++ b/packages/hooks/src/useControllableValue/index.ts
@@ -21,11 +21,11 @@ export interface StandardProps<T> {
 
 function useControllableValue<T = any>(
   props: StandardProps<T>,
-): [T, (v: SetStateAction<T>) => void];
+): [T, (v: SetStateAction<T>) => void | Promise<unknown>];
 function useControllableValue<T = any>(
   props?: Props,
   options?: Options<T>,
-): [T, (v: SetStateAction<T>, ...args: any[]) => void];
+): [T, (v: SetStateAction<T>, ...args: any[]) => void | Promise<unknown>];
 function useControllableValue<T = any>(props: Props = {}, options: Options<T> = {}) {
   const {
     defaultValue,
@@ -62,7 +62,7 @@ function useControllableValue<T = any>(props: Props = {}, options: Options<T> = 
       update();
     }
     if (props[trigger]) {
-      props[trigger](r, ...args);
+      return props[trigger](r, ...args);
     }
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. useControllableValue 的 onChange 不支持返回 Promise，在 onChange 中进行网络请求时，无法增加 loading
2. function useControllableValue<T = any>(
  props: StandardProps<T>,
): [T, (v: SetStateAction<T>) => void | Promise<unknown>]; // 增加返回 Promise
<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 | 可以在调用 setValue 时拿到 Promise 的返回值，在此前前后可以进行 loading 等操作。  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义已补充
- [x] Changelog 无须提供