### PR TITLE
fix: useAntdTable accept pageSizeOptions param

### DIFF
--- a/packages/hooks/src/useAntdTable/index.tsx
+++ b/packages/hooks/src/useAntdTable/index.tsx
@@ -28,6 +28,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
 
   const result = usePagination<TData, TParams>(service, {
     manual: true,
+    defaultPageSize: defaultParams?.[0]?.pageSize || 10,
     ...rest,
     onSuccess(...args) {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -261,6 +262,7 @@ const useAntdTable = <TData extends Data, TParams extends Params>(
         current: result.pagination.current,
         pageSize: result.pagination.pageSize,
         total: result.pagination.total,
+        pageSizeOptions: result.pagination.pageSizeOptions,
       },
     },
     search: {

--- a/packages/hooks/src/usePagination/index.ts
+++ b/packages/hooks/src/usePagination/index.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 import useRequest from '../useRequest';
 
@@ -8,10 +8,29 @@ const usePagination = <TData extends Data, TParams extends Params>(
   service: Service<TData, TParams>,
   options: PaginationOptions<TData, TParams> = {},
 ) => {
+  const defaultPageSizeOptions = [10, 20, 50, 100];
   const { defaultPageSize = 10, defaultCurrent = 1, ...rest } = options;
 
+  const pageSizeOptions = useMemo(() => {
+    if (defaultPageSizeOptions.includes(defaultPageSize)) {
+      return defaultPageSizeOptions;
+    } else {
+      return [...defaultPageSizeOptions, defaultPageSize].sort((a, b) => a - b);
+    }
+  }, [defaultPageSize]);
+
+  useEffect(() => {
+    console.log(pageSizeOptions, 'pageSizeOptions');
+  }, [pageSizeOptions]);
+
   const result = useRequest(service, {
-    defaultParams: [{ current: defaultCurrent, pageSize: defaultPageSize }],
+    defaultParams: [
+      {
+        current: defaultCurrent,
+        pageSize: defaultPageSize,
+        pageSizeOptions,
+      },
+    ],
     refreshDepsAction: () => {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       changeCurrent(1);
@@ -59,6 +78,7 @@ const usePagination = <TData extends Data, TParams extends Params>(
       pageSize,
       total,
       totalPage,
+      pageSizeOptions,
       onChange: useMemoizedFn(onChange),
       changeCurrent: useMemoizedFn(changeCurrent),
       changePageSize: useMemoizedFn(changePageSize),

--- a/packages/hooks/src/usePagination/types.ts
+++ b/packages/hooks/src/usePagination/types.ts
@@ -11,6 +11,7 @@ export type Service<TData extends Data, TParams extends Params> = (
 export interface PaginationResult<TData extends Data, TParams extends Params>
   extends Result<TData, TParams> {
   pagination: {
+    pageSizeOptions: number[];
     current: number;
     pageSize: number;
     total: number;


### PR DESCRIPTION

### 🤔 这个变动的性质是？
- ☑️ 日常 bug 修复

### 🔗 相关 Issue
https://github.com/alibaba/hooks/issues/2393

### 💡 需求背景和解决方案
1.  useAntdTable 设置默认分页大小后，切换分页大小，原来设置的pagesize被重置了 
2. 通过usePagination里多输出一个pageSizeOptions完成

### 📝 更新日志

修复了设置默认页数后, 分页器展示问题，保留默认分页条数展示

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fixed an issue where the pagination was displayed after setting the default number of pages       |
| 🇨🇳 中文 |   修复了设置默认页数后, 分页器展示问题     |

### ☑️ 请求合并前的自查清单

- ☑️ 文档已补充或无须补充
- ☑️ 代码演示已提供或无须提供
- ☑️ TypeScript 定义已补充或无须补充
- ☑️ Changelog 已提供或无须提供