### PR TITLE
perf(useDebounceEffect & useThrottleEffect): effectCallback called that do not rely on rerender

### DIFF
--- a/packages/hooks/src/useDebounceEffect/index.ts
+++ b/packages/hooks/src/useDebounceEffect/index.ts
@@ -1,25 +1,42 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import type { DependencyList, EffectCallback } from 'react';
 import type { DebounceOptions } from '../useDebounce/debounceOptions';
 import useDebounceFn from '../useDebounceFn';
-import useUpdateEffect from '../useUpdateEffect';
+import { isFunction } from '../utils';
+import useUnmount from '../useUnmount';
+import isDev from '../utils/isDev';
 
 function useDebounceEffect(
   effect: EffectCallback,
   deps?: DependencyList,
   options?: DebounceOptions,
 ) {
-  const [flag, setFlag] = useState({});
+  if (isDev) {
+    if (!isFunction(effect)) {
+      console.error(
+        `useDebounceEffect expected first parameter is a function, got ${typeof effect}`,
+      );
+    }
+  }
+
+  const cleanup = useRef<ReturnType<EffectCallback>>();
 
   const { run } = useDebounceFn(() => {
-    setFlag({});
+    if (isFunction(cleanup.current)) {
+      cleanup.current();
+    }
+    cleanup.current = effect();
   }, options);
 
   useEffect(() => {
     return run();
   }, deps);
 
-  useUpdateEffect(effect, [flag]);
+  useUnmount(() => {
+    if (isFunction(cleanup.current)) {
+      cleanup.current();
+    }
+  });
 }
 
 export default useDebounceEffect;

--- a/packages/hooks/src/useThrottleEffect/index.ts
+++ b/packages/hooks/src/useThrottleEffect/index.ts
@@ -1,25 +1,42 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import type { DependencyList, EffectCallback } from 'react';
 import type { ThrottleOptions } from '../useThrottle/throttleOptions';
 import useThrottleFn from '../useThrottleFn';
-import useUpdateEffect from '../useUpdateEffect';
+import isDev from '../utils/isDev';
+import { isFunction } from '../utils';
+import useUnmount from '../useUnmount';
 
 function useThrottleEffect(
   effect: EffectCallback,
   deps?: DependencyList,
   options?: ThrottleOptions,
 ) {
-  const [flag, setFlag] = useState({});
+  if (isDev) {
+    if (!isFunction(effect)) {
+      console.error(
+        `useThrottleEffect expected first parameter is a function, got ${typeof effect}`,
+      );
+    }
+  }
+
+  const cleanup = useRef<ReturnType<EffectCallback>>();
 
   const { run } = useThrottleFn(() => {
-    setFlag({});
+    if (isFunction(cleanup.current)) {
+      cleanup.current();
+    }
+    cleanup.current = effect();
   }, options);
 
   useEffect(() => {
     return run();
   }, deps);
 
-  useUpdateEffect(effect, [flag]);
+  useUnmount(() => {
+    if (isFunction(cleanup.current)) {
+      cleanup.current();
+    }
+  });
 }
 
 export default useThrottleEffect;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/alibaba/hooks/issues/2398

### 💡 需求背景和解决方案

#### 问题
这可能不是一个 bug，是一个性能问题。使用useDebounceEffect & useThrottleEffect ，当 callback 被执行前，多了一次额外的 rerender，即下图红色圈起来的部分。[demo请看这里](https://stackblitz.com/edit/stackblitz-starters-5hqe3i?file=src%2FApp.tsx)
![image](https://github.com/alibaba/hooks/assets/26155937/2be1bb26-708d-4570-b093-be07c6970f59)


#### 实现
上面的问题是由于执行 effectCallback 要依赖 state 的更新（对应源码 `useUpdateEffect(effect, [flag])`），这个机制引起的。这样做的缺点是想要执行 effectCallback，需要先 setState(xx) ，则会引起多一次额外的 rerender。
我认为可以通过一些方式解决此问题，但是需要注意不能丢失了 cleanup 功能（[参见文档](https://react.dev/reference/react/useEffect#useeffect)）。
- callback 的交给 run 方法及直接去触发即可。
- 补充 cleanup 功能。
  - 在每次执行 useUpdateEffect 前，先执行 cleanup。
  - 组件 unmount 时，执行 cleanup。


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
