### PR TITLE
fix(type): fixed up some types that are non-standard and errors on `useExteneral` hook

### DIFF
--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -31,7 +31,9 @@ interface LoadResult {
   ref: Element;
   status: Status;
 }
+
 type LoadExternal = <T>(path: string, props: Partial<T> | undefined) => LoadResult;
+
 const loadScript: LoadExternal = (path, props = {}) => {
   const script = document.querySelector(`script[src="${path}"]`);
 

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -32,7 +32,7 @@ interface LoadResult {
   status: Status;
 }
 
-type LoadExternal = <T>(path: string, props: Partial<T> | undefined) => LoadResult;
+type LoadExternal = <T>(path: string, props?: Partial<T>) => LoadResult;
 
 const loadScript: LoadExternal = (path, props = {}) => {
   const script = document.querySelector(`script[src="${path}"]`);

--- a/packages/hooks/src/useExternal/index.ts
+++ b/packages/hooks/src/useExternal/index.ts
@@ -27,12 +27,12 @@ const EXTERNAL_USED_COUNT: Record<string, number> = {};
 
 export type Status = 'unset' | 'loading' | 'ready' | 'error';
 
-interface loadResult {
+interface LoadResult {
   ref: Element;
   status: Status;
 }
-
-const loadScript = (path: string, props = {}): loadResult => {
+type LoadExternal = <T>(path: string, props: Partial<T> | undefined) => LoadResult;
+const loadScript: LoadExternal = (path, props = {}) => {
   const script = document.querySelector(`script[src="${path}"]`);
 
   if (!script) {
@@ -58,7 +58,7 @@ const loadScript = (path: string, props = {}): loadResult => {
   };
 };
 
-const loadCss = (path: string, props = {}): loadResult => {
+const loadCss: LoadExternal = (path, props = {}) => {
   const css = document.querySelector(`link[href="${path}"]`);
   if (!css) {
     const newCss = document.createElement('link');


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] TS类型重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

我在自己 `review`和 `clone` 这个`useExternal`hook 的时候出现了ts的报错
代码片段
<img width="776" alt="image" src="https://github.com/alibaba/hooks/assets/38754760/303ab941-7e1f-4aae-975c-659f48b39de0">

1. 在ts类型定义名字`loadResult`出现了小写不规范。
2. props没有定义类型，虽然你们的项目中`tsconfig.json`的一些配置项，很好的避免这个不太严格类型报错，但是如果我把代码clone到其他正常严格`tsconfig.json`配置是存在ts报错。
3. 同样错误出现了两处 `loadCss`和`loadScript`这两个函数中

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
