### PR TITLE
feature/imperative-set-timeout

### DIFF
--- a/packages/hooks/src/useTimeout/__tests__/index.test.ts
+++ b/packages/hooks/src/useTimeout/__tests__/index.test.ts
@@ -1,12 +1,14 @@
 import { renderHook } from '@testing-library/react';
-import useTimeout from '../index';
+import useTimeout, { type UseTimeoutOptions } from '../index';
 
 interface ParamsObj {
   fn: (...arg: any) => any;
   delay: number | undefined;
+  options?: UseTimeoutOptions;
 }
 
-const setUp = ({ fn, delay }: ParamsObj) => renderHook(() => useTimeout(fn, delay));
+const setUp = ({ fn, delay, options }: ParamsObj) =>
+  renderHook(() => useTimeout(fn, delay, options));
 
 describe('useTimeout', () => {
   jest.useFakeTimers();
@@ -44,5 +46,26 @@ describe('useTimeout', () => {
     jest.advanceTimersByTime(30);
     expect(callback).toHaveBeenCalledTimes(0);
     expect(clearTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('timeout should not be called if defaultActive is false ', () => {
+    const callback = jest.fn();
+
+    setUp({ fn: callback, delay: 20, options: { defaultActive: false } });
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(70);
+    expect(callback).not.toBeCalled();
+    expect(clearTimeout).toHaveBeenCalledTimes(0);
+  });
+
+  it('timeout should be called if defaultActive is true ', () => {
+    const callback = jest.fn();
+
+    setUp({ fn: callback, delay: 20, options: { defaultActive: true } });
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(70);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hooks/src/useTimeout/demo/demo2.tsx
+++ b/packages/hooks/src/useTimeout/demo/demo2.tsx
@@ -13,7 +13,7 @@ export default () => {
   const [count, setCount] = useState(0);
   const [delay, setDelay] = useState<number | undefined>(1000);
 
-  const clear = useTimeout(() => {
+  const { clear, isActive } = useTimeout(() => {
     setCount(count + 1);
   }, delay);
 
@@ -21,7 +21,17 @@ export default () => {
     <div>
       <p> count: {count} </p>
       <p style={{ marginTop: 16 }}> Delay: {delay} </p>
-      <button onClick={() => setDelay((t) => (!!t ? t + 1000 : 1000))} style={{ marginRight: 8 }}>
+      <div>
+        setTimeout status:{' '}
+        <span style={{ color: isActive ? 'green' : 'red' }}>
+          {isActive ? 'enabled' : 'disabled'}
+        </span>
+      </div>
+
+      <button
+        onClick={() => setDelay((t) => (!!t ? t + 1000 : 1000))}
+        style={{ marginRight: 8, marginTop: 16 }}
+      >
         Delay + 1000
       </button>
       <button

--- a/packages/hooks/src/useTimeout/demo/demo3.tsx
+++ b/packages/hooks/src/useTimeout/demo/demo3.tsx
@@ -1,0 +1,40 @@
+/**
+ * title: Imperative Usage
+ * desc: Run after calling `start` function
+ *
+ * title.zh-CN: 主动调用
+ * desc.zh-CN: 默认不启动计时器，调用start函数主动启用, 调用clear清除计时器
+ */
+
+import React, { useState } from 'react';
+import { useTimeout } from 'ahooks';
+
+export default () => {
+  const [state, setState] = useState(0);
+
+  const { start, clear, isActive } = useTimeout(
+    () => {
+      setState(state + 1);
+    },
+    2000,
+    { defaultActive: false },
+  );
+
+  return (
+    <div>
+      <div>
+        setTimeout status:{' '}
+        <span style={{ color: isActive ? 'green' : 'red' }}>
+          {isActive ? 'enabled' : 'disabled'}
+        </span>
+      </div>
+      <div style={{ marginTop: '12px' }}>Count: {state}</div>
+      <div style={{ marginTop: '24px' }}>
+        <button onClick={start}>start</button>
+        <button onClick={clear} style={{ marginLeft: '8px' }}>
+          clear
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/hooks/src/useTimeout/index.en-US.md
+++ b/packages/hooks/src/useTimeout/index.en-US.md
@@ -13,6 +13,7 @@ A hook that handles the `setTimeout` timer function.
 
 <code src="./demo/demo1.tsx" />
 <code src="./demo/demo2.tsx" />
+<code src="./demo/demo3.tsx" />
 
 ## API
 
@@ -20,18 +21,26 @@ A hook that handles the `setTimeout` timer function.
 useTimeout(
   fn: () => void,
   delay?: number | undefined
-): fn: () => void;
+  options?: { defaultActive?: boolean }
+): {
+  clear: () => void;
+  start: () => void;
+  isActive: boolean;
+};
 ```
 
 ### Params
 
-| Property | Description                                                                                                            | Type                    |
-| -------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| fn       | The function to be executed after `delay` milliseconds.                                                                | `() => void`            |
-| delay    | The number of milliseconds to wait before executing the function. The timer will be cancelled if delay is `undefined`. | `number` \| `undefined` |
+| Property              | Description                                                                                                            | Type                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| fn                    | The function to be executed after `delay` milliseconds.                                                                | `() => void`            |
+| delay                 | The number of milliseconds to wait before executing the function. The timer will be cancelled if delay is `undefined`. | `number` \| `undefined` |
+| options.defaultActive | setTimeout runs on mount if defaultActive is `true`                                                                    | boolean                 |
 
 ### Result
 
-| Property     | Description   | Type         |
-| ------------ | ------------- | ------------ |
-| clearTimeout | clear timeout | `() => void` |
+| Property | Description                                                                                    | Type         |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------ |
+| clear    | clear timeout                                                                                  | `() => void` |
+| start    | start timeout                                                                                  | `() => void` |
+| isActive | indicates whether setTimeout is active, remains `true` after setTimeout is running or finished | `boolean`    |

--- a/packages/hooks/src/useTimeout/index.ts
+++ b/packages/hooks/src/useTimeout/index.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useRef } from 'react';
 import useMemoizedFn from '../useMemoizedFn';
 import { isNumber } from '../utils';
 
-const useTimeout = (fn: () => void, delay?: number) => {
+export interface UseTimeoutOptions {
+  defaultActive?: boolean;
+}
+
+const useTimeout = (fn: () => void, delay?: number, options?: UseTimeoutOptions) => {
+  const { defaultActive = true } = options || {};
+
   const timerCallback = useMemoizedFn(fn);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -13,14 +19,26 @@ const useTimeout = (fn: () => void, delay?: number) => {
   }, []);
 
   useEffect(() => {
+    if (!defaultActive) return;
+
     if (!isNumber(delay) || delay < 0) {
       return;
     }
+
     timerRef.current = setTimeout(timerCallback, delay);
     return clear;
-  }, [delay]);
+  }, [delay, defaultActive]);
 
   return clear;
 };
+
+// const {
+//   start,
+//   pause,
+//   clear,
+//   isActive,
+// } = useTimeout(fn, delay, {
+//   defaultActive: false
+// })
 
 export default useTimeout;

--- a/packages/hooks/src/useTimeout/index.zh-CN.md
+++ b/packages/hooks/src/useTimeout/index.zh-CN.md
@@ -13,6 +13,7 @@ nav:
 
 <code src="./demo/demo1.tsx" />
 <code src="./demo/demo2.tsx" />
+<code src="./demo/demo3.tsx" />
 
 ## API
 
@@ -20,18 +21,26 @@ nav:
 useTimeout(
   fn: () => void,
   delay?: number | undefined
-): fn: () => void;
+  options?: { defaultActive?: boolean }
+): {
+  clear: () => void;
+  start: () => void;
+  isActive: boolean;
+};
 ```
 
 ### Params
 
-| 参数  | 说明                                                                       | 类型                    |
-| ----- | -------------------------------------------------------------------------- | ----------------------- |
-| fn    | 待执行函数                                                                 | `() => void`            |
-| delay | 定时时间（单位为毫秒）,支持动态变化，，当取值为 `undefined` 时会停止计时器 | `number` \| `undefined` |
+| 参数                  | 说明                                                                       | 类型                    |
+| --------------------- | -------------------------------------------------------------------------- | ----------------------- |
+| fn                    | 待执行函数                                                                 | `() => void`            |
+| delay                 | 定时时间（单位为毫秒）,支持动态变化，，当取值为 `undefined` 时会停止计时器 | `number` \| `undefined` |
+| options.defaultActive | 是否挂载时启动                                                             | `boolean`               |
 
 ### Result
 
-| 参数         | 说明       | 类型         |
-| ------------ | ---------- | ------------ |
-| clearTimeout | 清除定时器 | `() => void` |
+| 参数     | 说明                                   | 类型         |
+| -------- | -------------------------------------- | ------------ |
+| clear    | 清除定时器                             | `() => void` |
+| start    | 启动定时器                             | `() => void` |
+| isActive | 定时器运行状态，定时器运行后保持为true | `boolean`    |


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/alibaba/hooks/issues/2537

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
提供主动调用setTimeout的能力

```typescript
useTimeout(
  fn: () => void,
  delay?: number | undefined
  options?: { defaultActive?: boolean }
): {
  clear: () => void;
  start: () => void;
  isActive: boolean;
};
```

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
1. 修改返回值为对象类型  **【BREAKING CHANGE】**
1. 提供`start`和 `isActive`两个新的返回值，用户可主动调用start进行定时器执行。 **【BREAKING CHANGE】**
2. 提供options作为useTimeout的第三个参数，内含defaultActive，默认为true（兼容默认逻辑）


<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供