### PR TITLE
fix: useRequest pollingInterval invalid after staleTime  is enabled

### DIFF
--- a/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
@@ -116,4 +116,36 @@ describe('usePollingPlugin', () => {
     });
     await waitFor(() => expect(errorCallback).toHaveBeenCalledTimes(5));
   });
+
+  //github.com/alibaba/hooks/issues/2505
+  it('useRequest pollingInterval should work when set staleTime', async () => {
+    const callback = jest.fn();
+    act(() => {
+      hook = setUp(
+        () => {
+          callback();
+          return request(1);
+        },
+        {
+          staleTime: 3 * 1000,
+          pollingInterval: 1 * 1000,
+          cacheKey: 'testStaleTime',
+        },
+      );
+    });
+    expect(hook.result.current.loading).toBe(true);
+    act(() => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => expect(hook.result.current.loading).toBe(false));
+    expect(hook.result.current.data).toBe('success');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => expect(hook.result.current.loading).toBe(false));
+    expect(hook.result.current.data).toBe('success');
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/hooks/src/useRequest/doc/polling/polling.en-US.md
+++ b/packages/hooks/src/useRequest/doc/polling/polling.en-US.md
@@ -60,3 +60,4 @@ You can experience the effect through the following example.
 - If you set `options.manual = true`, the initialization will not start polling, you need start it by `run/runAsync`.
 - If the `pollingInterval` changes from 0 to a value greater than 0, polling will not start automatically, and you need start it by `run/runAsync`.
 - The polling logic is to wait for `pollingInterval` time after each request is completed, and then initiate the next request.
+- When `pollingInterval`, `cacheKey`, and `staleTime` are all set, the system will wait for a duration of `pollingInterval`. If the data is still within the freshness time, no request will be sent. If the data is no longer fresh, the next request will be initiated.

--- a/packages/hooks/src/useRequest/doc/polling/polling.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/polling/polling.zh-CN.md
@@ -60,3 +60,4 @@ const { data, run, cancel } = useRequest(getUsername, {
 - 如果设置 `options.manual = true`，则初始化不会启动轮询，需要通过 `run/runAsync` 触发开始。
 - 如果设置 `pollingInterval` 由 `0` 变成 `大于 0` 的值，不会启动轮询，需要通过 `run/runAsync` 触发开始。
 - 轮询原理是在每次请求完成后，等待 `pollingInterval` 时间，发起下一次请求。
+- 当同时设置了`pollingInterval`,`cacheKey`,`staleTime`后，等待 `pollingInterval` 时间，如果仍然在数据新鲜时间內,不会发送请求。如果不在数据新鲜时间內,则发起下一次请求。

--- a/packages/hooks/src/useRequest/src/types.ts
+++ b/packages/hooks/src/useRequest/src/types.ts
@@ -13,7 +13,12 @@ export interface FetchState<TData, TParams extends any[]> {
   data?: TData;
   error?: Error;
 }
-
+export type pluginsOptions = {
+  pollingNow?: boolean;
+  returnNow?: boolean;
+  stopNow?: boolean;
+  cacheData?: any;
+};
 export interface PluginReturn<TData, TParams extends any[]> {
   onBefore?: (params: TParams) =>
     | ({
@@ -29,7 +34,7 @@ export interface PluginReturn<TData, TParams extends any[]> {
     servicePromise?: Promise<TData>;
   };
 
-  onSuccess?: (data: TData, params: TParams) => void;
+  onSuccess?: (data: TData, params: TParams, options: pluginsOptions) => void;
   onError?: (e: Error, params: TParams) => void;
   onFinally?: (params: TParams, data?: TData, e?: Error) => void;
   onCancel?: () => void;
@@ -94,10 +99,10 @@ export interface Options<TData, TParams extends any[]> {
 }
 
 export type Plugin<TData, TParams extends any[]> = {
-  (fetchInstance: Fetch<TData, TParams>, options: Options<TData, TParams>): PluginReturn<
-    TData,
-    TParams
-  >;
+  (
+    fetchInstance: Fetch<TData, TParams>,
+    options: Options<TData, TParams>,
+  ): PluginReturn<TData, TParams>;
   onInit?: (options: Options<TData, TParams>) => Partial<FetchState<TData, TParams>>;
 };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix https://github.com/alibaba/hooks/issues/2505


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
发现是 plugin 之间相互影响了，staleTime 导致了缓存,使得returnNow要求立刻返回值, 而pollingInterval 要求轮询值, 导致了 useRequest 的 staleTime 和 pollingInterval 不能够按照预期工作。因为返回值后就永远不会轮询。

正确的做法应该是 判断应该是是处于 returnNow 和 pollingInterval 的交叉状态,如果是这个状态,那么将 缓存值传递到各个plugin的 onSuccess和onFinish等方法中去(原来的代码直接`return Promise.resolve`,导致轮询永远无法触发)，然后再执行 `return Promise.resolve` 。 假如不是这个交叉状态，按原来的逻辑走就行

然后原来的plugin中并不能共享 returnNow stopNow,pollingNow 之类的状态，插件中需要对这些状态进行判断,这个pr对上面的问题进行了简单的重构, 

补一个用于测试的实例
```tsx

import { useRequest } from 'ahooks';
import { useEffect } from 'react';
export default () => {
  let { run, loading } = useRequest(
    async (param) => {
      console.log('param');
      return new Promise((resolve) => {
        resolve(param);
      });
    },
    {
      staleTime: 3 * 1000,
      pollingInterval: 1 * 1000,
      cacheKey: 'DD',
      manual: true,
      onSuccess: (e) => {
        console.log('success', e, loading);
      },
    },
  );
  useEffect(() => {
    run('测试');
  }, []);
  return <div>测试</div>;
};

```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供