### PR TITLE
fix: 修复createDeepCompareEffect依赖浅拷贝导致的副作用执行

### DIFF
--- a/packages/hooks/src/createDeepCompareEffect/index.ts
+++ b/packages/hooks/src/createDeepCompareEffect/index.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import type { DependencyList, useEffect, useLayoutEffect } from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 import { depsEqual } from '../utils/depsEqual';
 
 type EffectHookType = typeof useEffect | typeof useLayoutEffect;
@@ -10,7 +11,7 @@ export const createDeepCompareEffect: CreateUpdateEffect = (hook) => (effect, de
   const signalRef = useRef<number>(0);
 
   if (deps === undefined || !depsEqual(deps, ref.current)) {
-    ref.current = deps;
+    ref.current = cloneDeep(deps);
     signalRef.current += 1;
   }
 


### PR DESCRIPTION

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[解决useDeepCompareEffect依赖浅拷贝导致的异常执行](https://github.com/alibaba/hooks/issues/2575) 


### 💡 需求背景和解决方案
**背景**：在使用useDeepCompareEffect时，依赖了一个对象，当对象变更时会将对象赋值给Form组件，当表单项更改会使得传入对象被修改，此时useDeepCompareEffect的data并没有改变，但useDeepCompareEffect会判断依赖变了，执行副作用，导致表单编辑内容丢失。
原因：useDeepCompareEffect存储依赖时是进行的浅拷贝，获取依赖对Form组件赋值时没有克隆，表单项修改导致传入对象被修改导致下一次hook执行时判断依赖更新了。
代码如下所示：
```
const Demo = (props)=> {
      const {data} = props;
      const formRef = useRef(null);
      useDeepCompareEffect(()=> {
          const curFormData = data;
         formRef. setFieldValue(curFormData);
      }, [data])
    
    return <Form ref={formRef}>more </Form>
}
```
**解决方案**：useDeepCompareEffect依赖的createDeepCompareEffect存储依赖时，使用深拷贝。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  fix: Avoid abnormal execution problems that may occur when the dependency is a reference data type and the side-effect function uses the dependency without cloning.        |
| 🇨🇳 中文 |     fix: 修复依赖为引用数据类型时，副作用函数使用依赖不克隆可能引发的异常执行问题    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

