### PR TITLE
fix: resolves depsEqual performance issues (#2577)

### DIFF
--- a/packages/hooks/src/createDeepCompareEffect/index.ts
+++ b/packages/hooks/src/createDeepCompareEffect/index.ts
@@ -10,9 +10,9 @@ export const createDeepCompareEffect: CreateUpdateEffect = (hook) => (effect, de
   const signalRef = useRef<number>(0);
 
   if (deps === undefined || !depsEqual(deps, ref.current)) {
-    ref.current = deps;
     signalRef.current += 1;
   }
+  ref.current = deps;
 
   hook(effect, [signalRef.current]);
 };

--- a/packages/hooks/src/utils/useDeepCompareWithTarget.ts
+++ b/packages/hooks/src/utils/useDeepCompareWithTarget.ts
@@ -13,9 +13,9 @@ const useDeepCompareEffectWithTarget = (
   const signalRef = useRef<number>(0);
 
   if (!depsEqual(deps, ref.current)) {
-    ref.current = deps;
     signalRef.current += 1;
   }
+  ref.current = deps;
 
   useEffectWithTarget(effect, [signalRef.current], target);
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/alibaba/hooks/issues/2577 [useDeepCompareEffect] 在组件re-render时进行depsEqual造成性能问题

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

**背景**： 在更新 State 为相同数据后，depsEqual 判断依赖数据没有变化，ref.current 的值没有进行更新，导致后续页面上组件因为其他State/Props进行re-render时，useDeepCompareEffect会一直进行深度对比，导致严重的性能问题（因为真实数据层级较多）。

**解决方案**： 无论 depsEqual 相同或者不同，都要记录上次 render 的依赖的变化。具体执行逻辑参考 [codesanbox]( https://codesandbox.io/p/sandbox/use-deep-compare-effect-t9f984?file=%2Fsrc%2FApp.tsx%3A31%2C5) 中的 newCreateDeepCompareEffect 。

**复现步骤**： 
1. 点击页面中的【重新设置相同的数据】
2. 点击【重新渲染】按钮
3. 观察控制台中的输出

createDeepCompareEffect 的 log 如下：
![image](https://github.com/alibaba/hooks/assets/19359849/74c87a2c-3460-4d34-a65f-aa7091cbe531)

useDeepCompareEffectNew 的 log 如下：
![image](https://github.com/alibaba/hooks/assets/19359849/24cf9a4b-14e1-463b-8dc3-54a0fe74eef8)

可以观察到，depsEqual 执行的判断明显减少

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Resolves depsEqual performance issues when references dependent on useDeepCompareEffect change     |
| 🇨🇳 中文 |    解决 useDeepCompareEffect 依赖的引用变化时 depsEqual 的性能问题      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供