### PR TITLE
refactor(useMount): no need to add optional when invoking fn

### DIFF
--- a/packages/hooks/src/useMount/index.ts
+++ b/packages/hooks/src/useMount/index.ts
@@ -12,7 +12,7 @@ const useMount = (fn: () => void) => {
   }
 
   useEffect(() => {
-    fn?.();
+    fn();
   }, []);
 };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

useMount 在前置逻辑中已经判断了是否为函数，所以在调用的时候不需要再加可选链去调用函数。


### 📝 更新日志
 
无

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供