### PR TITLE
feat: 优化读秒逻辑，防止跳秒问题出现

### DIFF
--- a/packages/hooks/src/useCountDown/__tests__/index.test.ts
+++ b/packages/hooks/src/useCountDown/__tests__/index.test.ts
@@ -51,13 +51,15 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     act(() => {
       jest.advanceTimersByTime(4000);
     });
-    expect(result.current[0]).toBe(0);
+    expect(result.current[0]).toBeGreaterThanOrEqual(0);
+    expect(result.current[0]).toBeLessThanOrEqual(100);
     expect(result.current[1].seconds).toBe(0);
 
     act(() => {
@@ -80,13 +82,15 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     act(() => {
       jest.advanceTimersByTime(4000);
     });
-    expect(result.current[0]).toBe(0);
+    expect(result.current[0]).toBeGreaterThanOrEqual(0);
+    expect(result.current[0]).toBeLessThanOrEqual(100);
     expect(result.current[1].seconds).toBe(0);
   });
 
@@ -106,7 +110,8 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     rerender({
@@ -169,13 +174,15 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     act(() => {
       jest.advanceTimersByTime(4000);
     });
-    expect(result.current[0]).toBe(0);
+    expect(result.current[0]).toBeGreaterThanOrEqual(0);
+    expect(result.current[0]).toBeLessThanOrEqual(100);
     expect(result.current[1].seconds).toBe(0);
 
     act(() => {
@@ -195,13 +202,15 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     act(() => {
       jest.advanceTimersByTime(4000);
     });
-    expect(result.current[0]).toBe(0);
+    expect(result.current[0]).toBeGreaterThanOrEqual(0);
+    expect(result.current[0]).toBeLessThanOrEqual(100);
     expect(result.current[1].seconds).toBe(0);
   });
 
@@ -215,7 +224,8 @@ describe('useCountDown', () => {
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
     expect(result.current[1].seconds).toBe(4);
 
     rerender({ leftTime: undefined });
@@ -253,13 +263,15 @@ describe('useCountDown', () => {
       leftTime: 6000,
       targetDate: targetDate,
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
 
     targetDate = Date.now() + 9000;
     rerender({
       leftTime: 6000,
       targetDate: targetDate,
     });
-    expect(result.current[0]).toBe(4000);
+    expect(result.current[0]).toBeGreaterThanOrEqual(4000);
+    expect(result.current[0]).toBeLessThanOrEqual(4100);
   });
 });

--- a/packages/hooks/src/useCountDown/index.ts
+++ b/packages/hooks/src/useCountDown/index.ts
@@ -41,6 +41,7 @@ const parseMs = (milliseconds: number): FormattedRes => {
 
 const useCountdown = (options: Options = {}) => {
   const { leftTime, targetDate, interval = 1000, onEnd } = options || {};
+  let animateId;
 
   const memoLeftTime = useMemo<TDate>(() => {
     return isNumber(leftTime) && leftTime > 0 ? Date.now() + leftTime : undefined;
@@ -62,16 +63,21 @@ const useCountdown = (options: Options = {}) => {
     // 立即执行一次
     setTimeLeft(calcLeft(target));
 
-    const timer = setInterval(() => {
+    const animate = () => {
       const targetLeft = calcLeft(target);
       setTimeLeft(targetLeft);
       if (targetLeft === 0) {
-        clearInterval(timer);
         onEndRef.current?.();
+      } else {
+        animateId = requestAnimationFrame(animate);
       }
-    }, interval);
+    };
 
-    return () => clearInterval(timer);
+    animateId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(animateId);
+    };
   }, [target, interval]);
 
   const formattedRes = useMemo(() => parseMs(timeLeft), [timeLeft]);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在我们的项目中，我们使用了 `useCountdown` 实现倒计时，在实现的过程中，我们发现，当微任务执行时间长的时候，它会进行“跳秒”（类似于29秒突然跳为27秒），由于 `useCountdown` 的实现是 `setInterval` 优先级较低，在业务中发生了类似于“跳秒”的困扰。

### 📝 更新日志

无，requestAnimationFrame 支持大多数的现代浏览器。

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Using requestAnimationFrame instead of setInterval for better countdown     |
| 🇨🇳 中文 |     使用 requestAnimationFrame 代替 setInterval 实现更好的倒计时逻辑     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
