### PR TITLE
chore: fix link & add trend chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://ahooks.js.org">
-    <img width="200" src="https://ahooks.js.org/logo.svg">
+  <a href="https://ahooks.pages.dev">
+    <img width="200" src="https://ahooks.pages.dev/logo.svg">
   </a>
 </p>
 
@@ -24,8 +24,8 @@ English | [简体中文](https://github.com/alibaba/hooks/blob/master/README.zh-
 
 ## 📚 Documentation
 
-- [English](https://ahooks.js.org/)
-- [中文](https://ahooks.js.org/zh-CN/)
+- [English](https://ahooks.pages.dev/)
+- [中文](https://ahooks.pages.dev/zh-CN/)
 
 ## ✨ Features
 
@@ -57,6 +57,14 @@ import { useRequest } from 'ahooks';
 ## 💻 Online Demo
 
 [![Edit demo for ahooks](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/demo-for-ahooks-forked-fg79k?file=/src/App.js)
+
+## 🔥 Usage Trend
+
+[Usage Trend of ahooks](https://npm-compare.com/ahooks#timeRange=THREE_YEARS)
+  
+<a href="https://npm-compare.com/ahooks#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/ahooks.png" width="50%" alt="NPM Usage Trend of ahooks" />
+</a>
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
This PR updates the documentation to fix the broken link to `ahooks.js.org`, replacing it with `ahooks.pages.dev`. 

Additionally, I have added a link to the usage trend of ahooks. This trend image can help new users understand the package's popularity and encourage its adoption. As one of the main maintainers of this service, I’m also available to assist with adding new features if you needed.

Summary:
- Updated the documentation links to ahooks.pages.dev.
- Added a image for tracking usage trends.