### PR TITLE
fix: createUseStorageState 3.7.7 以上版本返回 undefined 类型问题

### DIFF
--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -40,7 +40,7 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
       return JSON.stringify(value);
     };
 
-    const deserializer = (value: string): T => {
+    const deserializer = (value: string) => {
       if (options.deserializer) {
         return options.deserializer(value);
       }
@@ -62,13 +62,13 @@ export function createUseStorageState(getStorage: () => Storage | undefined) {
       return options.defaultValue;
     }
 
-    const [state, setState] = useState(getStoredValue);
+    const [state, setState] = useState<T>(getStoredValue);
 
     useUpdateEffect(() => {
       setState(getStoredValue());
     }, [key]);
 
-    const updateState = (value?: SetState<T>) => {
+    const updateState = (value: SetState<T>) => {
       const currentState = isFunction(value) ? value(state) : value;
 
       if (!listenStorageChange) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<img width="905" alt="image" src="https://github.com/user-attachments/assets/c188129b-7cec-4d1d-bdee-dc78967b53ae">

### 💡 需求背景和解决方案

useSessionStorageState 在 3.7.7 及以上版本设置了类型会返回设置的类型 + undefined

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

无风险，仅修改类型

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
