### PR TITLE
fix: 修复useRequest在启动两个以上轮询时，设置页面隐藏停止轮询，页面重新显示时，有请求不自动开始轮询的问题。

### DIFF
--- a/packages/hooks/src/useRequest/src/utils/subscribeFocus.ts
+++ b/packages/hooks/src/useRequest/src/utils/subscribeFocus.ts
@@ -5,25 +5,19 @@ import isOnline from './isOnline';
 
 type Listener = () => void;
 
-const listeners: Listener[] = [];
+const listeners = new Set<Listener>();
 
 function subscribe(listener: Listener) {
-  listeners.push(listener);
+  listeners.add(listener);
   return function unsubscribe() {
-    const index = listeners.indexOf(listener);
-    if (index > -1) {
-      listeners.splice(index, 1);
-    }
+    listeners.has(listener) && listeners.delete(listener);
   };
 }
 
 if (isBrowser) {
   const revalidate = () => {
     if (!isDocumentVisible() || !isOnline()) return;
-    for (let i = 0; i < listeners.length; i++) {
-      const listener = listeners[i];
-      listener();
-    }
+    listeners.forEach((listener) => listener());
   };
   window.addEventListener('visibilitychange', revalidate, false);
   window.addEventListener('focus', revalidate, false);

--- a/packages/hooks/src/useRequest/src/utils/subscribeReVisible.ts
+++ b/packages/hooks/src/useRequest/src/utils/subscribeReVisible.ts
@@ -3,23 +3,19 @@ import isDocumentVisible from './isDocumentVisible';
 
 type Listener = () => void;
 
-const listeners: Listener[] = [];
+const listeners = new Set<Listener>();
 
 function subscribe(listener: Listener) {
-  listeners.push(listener);
+  listeners.add(listener);
   return function unsubscribe() {
-    const index = listeners.indexOf(listener);
-    listeners.splice(index, 1);
+    listeners.has(listener) && listeners.delete(listener);
   };
 }
 
 if (isBrowser) {
   const revalidate = () => {
     if (!isDocumentVisible()) return;
-    for (let i = 0; i < listeners.length; i++) {
-      const listener = listeners[i];
-      listener();
-    }
+    listeners.forEach((listener) => listener());
   };
   window.addEventListener('visibilitychange', revalidate, false);
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [√] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无issue，使用过程中开启多个轮询并设置pollingWhenHidden为false时，页面隐藏再打开，部分接口没有重新开始轮询；
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 修复问题：当开启多个轮询并设置pollingWhenHidden为false时，页面隐藏再打开，所有接口都应该重新开始轮询。
2. 修改方案：使用Set代替数组，使删除回调更精准。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

修复问题：当同时开启多个请求轮询，设置pollingWhenHidden为false时，页面隐藏再次打开，有的接口不会重新开始轮询；

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix the issue: When multiple request polling is enabled simultaneously and pollingWhenHidden is set to false, some interfaces do not restart polling when the page is hidden and then reopened. |
| 🇨🇳 中文 | 修复问题：当同时开启多个请求轮询，设置pollingWhenHidden为false时，页面隐藏再次打开，部分接口不重新开始轮询的问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
