### PR TITLE
chore: add onCancel for useRequest

### DIFF
--- a/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
@@ -62,6 +62,7 @@ Next, we will demonstrate the difference between `run` and `runAsync` through th
 - `onSuccess`: Triggered when the request is resolved
 - `onError`: Triggered when the request is rejected
 - `onFinally`: Triggered when the request is completed
+- `onCancel`: Triggered when the request is canceled
 
 <code src="./demo/lifeCycle.tsx" />
 

--- a/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
@@ -62,6 +62,7 @@ const { loading, run, runAsync } = useRequest(service, {
 - `onSuccess`：请求成功触发
 - `onError`：请求失败触发
 - `onFinally`：请求完成触发
+- `onCancel`：请求取消触发
 
 <code src="./demo/lifeCycle.tsx" />
 

--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -135,12 +135,15 @@ export default class Fetch<TData, TParams extends any[]> {
     });
   }
 
-  cancel() {
+  cancel(isUnmount = false) {
     this.count += 1;
     this.setState({
       loading: false,
     });
 
+    if(!isUnmount){
+      this.options.onCancel?.();
+    }
     this.runPluginHandler('onCancel');
   }
 

--- a/packages/hooks/src/useRequest/src/types.ts
+++ b/packages/hooks/src/useRequest/src/types.ts
@@ -46,6 +46,7 @@ export interface Options<TData, TParams extends any[]> {
   onError?: (e: Error, params: TParams) => void;
   // formatResult?: (res: any) => TData;
   onFinally?: (params: TParams, data?: TData, e?: Error) => void;
+  onCancel?: () => void;
 
   defaultParams?: TParams;
 

--- a/packages/hooks/src/useRequest/src/useRequestImplement.ts
+++ b/packages/hooks/src/useRequest/src/useRequestImplement.ts
@@ -56,7 +56,7 @@ function useRequestImplement<TData, TParams extends any[]>(
   });
 
   useUnmount(() => {
-    fetchInstance.cancel();
+    fetchInstance.cancel(true);
   });
 
   return {


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. `useRequest`对外暴露的`cancel`本质上是JS层的中断，并且没有对应生命周期回调。因此增加`onCancel`，用于请求取消时的额外操作，如用户行为埋点、请求服务的真实取消等。
2. 列出最终的 API 实现和用法。
```ts
const { loading, data, cancel } = useRequest( service, { onCancel?: () => {
   console.log('do here when cancel trigger')
}}
```
3. 涉及UI/交互变动需要有截图或 GIF - 无。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇨🇳 中文 |   组件卸载时 onCancel生命周期  不会被触发     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供