### PR TITLE
fix: 修复readyState判断问题

### DIFF
--- a/packages/hooks/src/useWebSocket/index.ts
+++ b/packages/hooks/src/useWebSocket/index.ts
@@ -43,17 +43,18 @@ export default function useWebSocket(socketUrl: string, options: Options = {}): 
     protocols,
   } = options;
 
+  const [latestMessage, setLatestMessage] = useState<WebSocketEventMap['message']>();
+  const [readyState, setReadyState] = useState<ReadyState>(ReadyState.Closed);
+
   const onOpenRef = useLatest(onOpen);
   const onCloseRef = useLatest(onClose);
   const onMessageRef = useLatest(onMessage);
   const onErrorRef = useLatest(onError);
+  const readyStateRef = useLatest(readyState);
 
   const reconnectTimesRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const websocketRef = useRef<WebSocket>();
-
-  const [latestMessage, setLatestMessage] = useState<WebSocketEventMap['message']>();
-  const [readyState, setReadyState] = useState<ReadyState>(ReadyState.Closed);
 
   const reconnect = () => {
     if (
@@ -123,7 +124,7 @@ export default function useWebSocket(socketUrl: string, options: Options = {}): 
   };
 
   const sendMessage: WebSocket['send'] = (message) => {
-    if (readyState === ReadyState.Open) {
+    if (readyStateRef.current === ReadyState.Open) {
       websocketRef.current?.send(message);
     } else {
       throw new Error('WebSocket disconnected');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
实际项目使用的时候，websocekt建立连接的时候，readyState应该为ReadyState.Open状态。但是刚开始连接就想发条消息的时候，由于判断问题导致一直抛出throw new Error('WebSocket disconnected')，导致消息无法发出。现使用useLatest解决，这个改动是我在实际项目中先改动了，现在给提个PR。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | fix: fixed the issue of readyState judgment |
| 🇨🇳 中文 | fix: 修复readyState判断问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
