### PR TITLE
fix: 修复useAntdTable在manual=true时，初始化仍然发起请求的问题

### DIFF
--- a/packages/hooks/src/createDeepCompareEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/createDeepCompareEffect/__tests__/index.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useEffect, useLayoutEffect, useState, act } from 'react';
 import { createDeepCompareEffect } from '../index';
 
 describe('createDeepCompareEffect', () => {

--- a/packages/hooks/src/createUseStorageState/__tests__/index.test.ts
+++ b/packages/hooks/src/createUseStorageState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import type { Options } from '../index';
 import { createUseStorageState } from '../index';
 

--- a/packages/hooks/src/useAntdTable/__tests__/index.test.ts
+++ b/packages/hooks/src/useAntdTable/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import { sleep } from '../../utils/testingHelpers';
 import useAntdTable from '../index';
 

--- a/packages/hooks/src/useAsyncEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/useAsyncEffect/__tests__/index.test.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import useAsyncEffect from '../index';
-import { useState } from 'react';
+import { useState, act } from 'react';
 import { sleep } from '../../utils/testingHelpers';
 
 describe('useAsyncEffect', () => {

--- a/packages/hooks/src/useBoolean/__tests__/index.test.ts
+++ b/packages/hooks/src/useBoolean/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useBoolean from '../index';
 
 const setUp = (defaultValue?: boolean) => renderHook(() => useBoolean(defaultValue));

--- a/packages/hooks/src/useControllableValue/__tests__/index.test.ts
+++ b/packages/hooks/src/useControllableValue/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useControllableValue, { Options, Props } from '../index';
 
 describe('useControllableValue', () => {

--- a/packages/hooks/src/useCookieState/__tests__/index.test.tsx
+++ b/packages/hooks/src/useCookieState/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useCookieState from '../index';
 import type { Options } from '../index';
 import Cookies from 'js-cookie';

--- a/packages/hooks/src/useCountDown/__tests__/index.test.ts
+++ b/packages/hooks/src/useCountDown/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import type { Options } from '../index';
 import useCountDown from '../index';
 

--- a/packages/hooks/src/useCounter/__tests__/index.test.ts
+++ b/packages/hooks/src/useCounter/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useCounter, { Options } from '../index';
 
 const setUp = (init?: number, options?: Options) => renderHook(() => useCounter(init, options));

--- a/packages/hooks/src/useCreation/__tests__/index.test.ts
+++ b/packages/hooks/src/useCreation/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useCreation from '../index';
 

--- a/packages/hooks/src/useDebounce/__tests__/index.test.ts
+++ b/packages/hooks/src/useDebounce/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useDebounce from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useDebounceEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/useDebounceEffect/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useDebounceEffect from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useDebounceFn/__tests__/index.test.ts
+++ b/packages/hooks/src/useDebounceFn/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { sleep } from '../../utils/testingHelpers';
 import useDebounceFn from '../index';
 

--- a/packages/hooks/src/useDeepCompareEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/useDeepCompareEffect/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useDeepCompareEffect from '../index';
 

--- a/packages/hooks/src/useDeepCompareLayoutEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/useDeepCompareLayoutEffect/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useDeepCompareLayoutEffect from '../index';
 

--- a/packages/hooks/src/useDocumentVisibility/__tests__/index.test.ts
+++ b/packages/hooks/src/useDocumentVisibility/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import useDocumentVisibility from '../index';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 
 const mockIsBrowser = jest.fn();
 const mockDocumentVisibilityState = jest.spyOn(document, 'visibilityState', 'get');

--- a/packages/hooks/src/useDynamicList/__tests__/index.test.ts
+++ b/packages/hooks/src/useDynamicList/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useDynamicList from '../index';
 
 describe('useDynamicList', () => {

--- a/packages/hooks/src/useEventEmitter/__tests__/index.test.ts
+++ b/packages/hooks/src/useEventEmitter/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useEventEmitter from '../index';
 

--- a/packages/hooks/src/useEventTarget/__tests__/index.test.ts
+++ b/packages/hooks/src/useEventTarget/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useEventTarget from '../index';
 
 describe('useEventTarget', () => {

--- a/packages/hooks/src/useExternal/__tests__/index.test.ts
+++ b/packages/hooks/src/useExternal/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useExternal, { Options } from '../index';
 import { fireEvent } from '@testing-library/react';
 

--- a/packages/hooks/src/useFullscreen/__tests__/index.test.ts
+++ b/packages/hooks/src/useFullscreen/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useFullscreen from '../index';
 import type { Options } from '../index';
 import type { BasicTarget } from '../../utils/domTarget';

--- a/packages/hooks/src/useFusionTable/__tests__/index.test.ts
+++ b/packages/hooks/src/useFusionTable/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useFusionTable from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useGetState/__tests__/index.test.ts
+++ b/packages/hooks/src/useGetState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useGetState from '../index';
 
 describe('useGetState', () => {

--- a/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
+++ b/packages/hooks/src/useHistoryTravel/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useHistoryTravel from '../index';
 
 describe('useHistoryTravel', () => {

--- a/packages/hooks/src/useHover/__tests__/index.test.tsx
+++ b/packages/hooks/src/useHover/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 // write your test cases here
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import useHover from '../index';
 

--- a/packages/hooks/src/useInViewport/__tests__/index.test.ts
+++ b/packages/hooks/src/useInViewport/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useInViewport from '../index';
 
 const targetEl = document.createElement('div');

--- a/packages/hooks/src/useInfiniteScroll/__tests__/index.test.ts
+++ b/packages/hooks/src/useInfiniteScroll/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useInfiniteScroll from '..';
 import type { Data, Service, InfiniteScrollOptions } from '../types';
 import { sleep } from '../../utils/testingHelpers';

--- a/packages/hooks/src/useLocalStorageState/__tests__/index.test.ts
+++ b/packages/hooks/src/useLocalStorageState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import type { Options } from '../../createUseStorageState';
 import useLocalStorageState from '../index';
 

--- a/packages/hooks/src/useLockFn/__tests__/index.test.ts
+++ b/packages/hooks/src/useLockFn/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useRef, useCallback, useState } from 'react';
 import useLockFn from '../index';
 import { sleep } from '../../utils/testingHelpers';

--- a/packages/hooks/src/useMap/__tests__/index.test.ts
+++ b/packages/hooks/src/useMap/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useMap from '../index';
 
 const setup = (initialMap?: Iterable<[any, any]>) => renderHook(() => useMap(initialMap));

--- a/packages/hooks/src/useMemoizedFn/__tests__/index.test.ts
+++ b/packages/hooks/src/useMemoizedFn/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useMemoizedFn from '../';
 

--- a/packages/hooks/src/useNetwork/__tests__/index.test.ts
+++ b/packages/hooks/src/useNetwork/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import useNetwork from '../index';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 
 describe('useNetwork', () => {
   it('toggle network state', () => {

--- a/packages/hooks/src/useRafState/__tests__/index.test.ts
+++ b/packages/hooks/src/useRafState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useRafState from '../index';
 
 describe('useRafState', () => {

--- a/packages/hooks/src/useReactive/__tests__/index.test.tsx
+++ b/packages/hooks/src/useReactive/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, renderHook, act } from '@testing-library/react';
-import React from 'react';
+import { fireEvent, render, renderHook } from '@testing-library/react';
+import React, { act } from 'react';
 import useReactive from '../';
 
 const Demo = () => {

--- a/packages/hooks/src/useRequest/__tests__/useAutoRunPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useAutoRunPlugin.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/useCachePlugin.test.tsx
+++ b/packages/hooks/src/useRequest/__tests__/useCachePlugin.test.tsx
@@ -1,5 +1,6 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { render } from '@testing-library/react';
+import { act } from 'react';
 import useRequest, { clearCache } from '../index';
 import { request } from '../../utils/testingHelpers';
 import React, { useState } from 'react';

--- a/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/useLoadingDelayPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useLoadingDelayPlugin.test.ts
@@ -1,5 +1,6 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import type { RenderHookResult } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/usePollingPlugin.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/useRefreshOnWindowFocusPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useRefreshOnWindowFocusPlugin.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent , renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/useRetryPlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useRetryPlugin.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.test.ts
+++ b/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useRequest from '../index';
 import { request } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useResetState/__tests__/index.test.ts
+++ b/packages/hooks/src/useResetState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useResetState from '../index';
 
 describe('useResetState', () => {

--- a/packages/hooks/src/useResponsive/__tests__/index.test.ts
+++ b/packages/hooks/src/useResponsive/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '../../utils/tests';
+import { renderHook } from '../../utils/tests';
+import { act } from 'react';
 import useResponsive from '../';
 
 describe('useResponsive', () => {

--- a/packages/hooks/src/useSafeState/__tests__/index.test.ts
+++ b/packages/hooks/src/useSafeState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useSafeState from '../index';
 
 describe('useSetState', () => {

--- a/packages/hooks/src/useSelections/__tests__/index.test.ts
+++ b/packages/hooks/src/useSelections/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { useState } from 'react';
 import useSelections from '../index';
 import type { Options } from '../index';

--- a/packages/hooks/src/useSessionStorageState/__tests__/index.test.ts
+++ b/packages/hooks/src/useSessionStorageState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useSessionStorageState from '../index';
 
 describe('useSessionStorageState', () => {

--- a/packages/hooks/src/useSet/__tests__/index.test.ts
+++ b/packages/hooks/src/useSet/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useSet from '../index';
 
 const setUp = <K>(initialSet?: Iterable<K>) => renderHook(() => useSet(initialSet));

--- a/packages/hooks/src/useSetState/__tests__/index.test.ts
+++ b/packages/hooks/src/useSetState/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useSetState from '../index';
 
 describe('useSetState', () => {

--- a/packages/hooks/src/useSize/__tests__/index.test.tsx
+++ b/packages/hooks/src/useSize/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import { renderHook, act, render, screen } from '@testing-library/react';
+import React, { useRef ,act } from 'react';
+import { renderHook, render, screen } from '@testing-library/react';
 import useSize from '../index';
 
 let callback;

--- a/packages/hooks/src/useTextSelection/__tests__/index.test.ts
+++ b/packages/hooks/src/useTextSelection/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useTextSelection from '../index';
 
 // test about Resize Observer see https://github.com/que-etc/resize-observer-polyfill/tree/master/tests

--- a/packages/hooks/src/useTheme/__test__/index.test.ts
+++ b/packages/hooks/src/useTheme/__test__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useTheme from '../index';
 
 describe('useTheme', () => {

--- a/packages/hooks/src/useThrottle/__tests__/index.test.ts
+++ b/packages/hooks/src/useThrottle/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useThrottle from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useThrottleEffect/__tests__/index.test.ts
+++ b/packages/hooks/src/useThrottleEffect/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useThrottleEffect from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useThrottleFn/__tests__/index.test.ts
+++ b/packages/hooks/src/useThrottleFn/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useThrottleFn from '../index';
 import { sleep } from '../../utils/testingHelpers';
 

--- a/packages/hooks/src/useTitle/__tests__/index.test.ts
+++ b/packages/hooks/src/useTitle/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useTitle from '../index';
 
 describe('useTitle', () => {

--- a/packages/hooks/src/useToggle/__tests__/index.test.ts
+++ b/packages/hooks/src/useToggle/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useToggle from '../index';
 
 const callToggle = (hook: any) => {

--- a/packages/hooks/src/useUpdate/__tests__/index.test.ts
+++ b/packages/hooks/src/useUpdate/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useUpdate from '..';
 import useMemoizedFn from '../../useMemoizedFn';
 

--- a/packages/hooks/src/useVirtualList/__tests__/index.test.ts
+++ b/packages/hooks/src/useVirtualList/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import useVirtualList, { Options } from '../index';
 
 describe('useVirtualList', () => {

--- a/packages/hooks/src/useWebSocket/__tests__/index.test.ts
+++ b/packages/hooks/src/useWebSocket/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import WS from 'jest-websocket-mock';
 import { sleep } from '../../utils/testingHelpers';
 import useWebSocket, { ReadyState } from '../index';

--- a/packages/hooks/src/useWhyDidYouUpdate/__tests__/index.test.ts
+++ b/packages/hooks/src/useWhyDidYouUpdate/__tests__/index.test.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import useWhyDidYouUpdate from '../index';
-import { useState } from 'react';
+import { useState, act } from 'react';
 
 describe('useWhyDidYouUpdate', () => {
   it('should work', () => {

--- a/packages/use-url-state/src/__tests__/browser.test.tsx
+++ b/packages/use-url-state/src/__tests__/browser.test.tsx
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { setup } from '.';
 
 describe('useUrlState', () => {

--- a/packages/use-url-state/src/__tests__/router.test.tsx
+++ b/packages/use-url-state/src/__tests__/router.test.tsx
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { setup } from '.';
 
 describe('React Router V6', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/alibaba/hooks/issues/2687
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
useAntdTable档manual=true，初始化时仍然会触发查询
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fix: Fix the issue that when manual=true for useAntdTable, requests are still initiated during initialization.       |
| 🇨🇳 中文 |    fix: 修复useAntdTable在manual=true时，初始化仍然发起请求的问题      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
