### PR TITLE
feat: add useIndexDBState hook

### DIFF
--- a/packages/hooks/src/useIndexDBState/README.md
+++ b/packages/hooks/src/useIndexDBState/README.md
@@ -1,0 +1,92 @@
+# useIndexDBState
+
+A React Hook that stores state into IndexedDB.
+
+## Examples
+
+### Basic usage
+
+```jsx
+import React from 'react';
+import { useIndexDBState } from 'ahooks';
+
+export default function Demo() {
+  const [message, setMessage] = useIndexDBState('message', {
+    defaultValue: 'Hello',
+  });
+
+  return (
+    <>
+      <input
+        value={message || ''}
+        onChange={(e) => setMessage(e.target.value)}
+      />
+      <button onClick={() => setMessage(undefined)}>Reset</button>
+    </>
+  );
+}
+```
+
+### Store complex object
+
+```jsx
+import React from 'react';
+import { useIndexDBState } from 'ahooks';
+
+export default function Demo() {
+  const [user, setUser] = useIndexDBState('user', {
+    defaultValue: { name: 'Ahooks', age: 1 },
+  });
+
+  return (
+    <>
+      <pre>{JSON.stringify(user, null, 2)}</pre>
+      <button
+        onClick={() => setUser({ name: 'New Name', age: 2 })}
+      >
+        Update User
+      </button>
+    </>
+  );
+}
+```
+
+## API
+
+```typescript
+type SetState<S> = S | ((prevState?: S) => S);
+
+interface Options<T> {
+  defaultValue?: T | (() => T);
+  dbName?: string;
+  storeName?: string;
+  version?: number;
+  onError?: (error: unknown) => void;
+}
+
+const [state, setState] = useIndexDBState<T>(key: string, options?: Options<T>);
+```
+
+### Params
+
+| Property | Description | Type | Default |
+|----------|-------------|------|---------|
+| key | The key of the IndexedDB record | `string` | - |
+| options | Optional configuration | `Options` | - |
+
+### Options
+
+| Property | Description | Type | Default |
+|----------|-------------|------|---------|
+| defaultValue | Default value | `T \| (() => T)` | `undefined` |
+| dbName | Name of the IndexedDB database | `string` | `ahooks-indexdb` |
+| storeName | Name of the object store | `string` | `ahooks-store` |
+| version | Version of the database | `number` | `1` |
+| onError | Error handler | `(error: unknown) => void` | `(e) => console.error(e)` |
+
+### Result
+
+| Property | Description | Type |
+|----------|-------------|------|
+| state | Current state | `T` |
+| setState | Set state | `(value?: SetState<T>) => void` | 

--- a/packages/hooks/src/useIndexDBState/__tests__/index.test.ts
+++ b/packages/hooks/src/useIndexDBState/__tests__/index.test.ts
@@ -1,0 +1,116 @@
+import { renderHook, act } from '@testing-library/react';
+import useIndexDBState from '../index';
+
+// 模拟 IndexedDB
+const mockIndexedDB = {
+  open: jest.fn(),
+};
+
+const mockIDBOpenDBRequest = {
+  onerror: null,
+  onsuccess: null,
+  onupgradeneeded: null,
+  result: {
+    transaction: jest.fn(),
+    close: jest.fn(),
+    objectStoreNames: {
+      contains: jest.fn().mockReturnValue(false),
+    },
+    createObjectStore: jest.fn(),
+  },
+};
+
+const mockObjectStore = {
+  get: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockTransaction = {
+  objectStore: jest.fn().mockReturnValue(mockObjectStore),
+};
+
+// 模拟 window.indexedDB
+Object.defineProperty(window, 'indexedDB', {
+  value: mockIndexedDB,
+  writable: true,
+});
+
+describe('useIndexDBState', () => {
+  beforeEach(() => {
+    // 设置全局 indexedDB 模拟
+    mockIndexedDB.open.mockReturnValue(mockIDBOpenDBRequest);
+    mockIDBOpenDBRequest.result.transaction.mockReturnValue(mockTransaction);
+    
+    // 清除之前的模拟调用
+    jest.clearAllMocks();
+  });
+
+  it('should initialize with default value', async () => {
+    const { result } = renderHook(() =>
+      useIndexDBState('test-key', {
+        defaultValue: 'default value',
+      }),
+    );
+
+    expect(result.current[0]).toBe('default value');
+  });
+
+  it('should update state when setState is called', async () => {
+    const { result } = renderHook(() =>
+      useIndexDBState('test-key', {
+        defaultValue: 'default value',
+      }),
+    );
+
+    act(() => {
+      result.current[1]('new value');
+    });
+
+    expect(result.current[0]).toBe('new value');
+  });
+
+  it('should handle function updater', async () => {
+    const { result } = renderHook(() =>
+      useIndexDBState('test-key', {
+        defaultValue: 'default value',
+      }),
+    );
+
+    act(() => {
+      result.current[1]((prev) => `${prev} updated`);
+    });
+
+    expect(result.current[0]).toBe('default value updated');
+  });
+
+  it('should handle undefined value', async () => {
+    const { result } = renderHook(() =>
+      useIndexDBState('test-key', {
+        defaultValue: 'default value',
+      }),
+    );
+
+    act(() => {
+      result.current[1](undefined);
+    });
+
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('should call onError when an error occurs', async () => {
+    const onError = jest.fn();
+    mockIndexedDB.open.mockImplementationOnce(() => {
+      throw new Error('Test error');
+    });
+
+    renderHook(() =>
+      useIndexDBState('test-key', {
+        defaultValue: 'default value',
+        onError,
+      }),
+    );
+
+    expect(onError).toHaveBeenCalled();
+  });
+}); 

--- a/packages/hooks/src/useIndexDBState/demo/demo1.tsx
+++ b/packages/hooks/src/useIndexDBState/demo/demo1.tsx
@@ -1,0 +1,40 @@
+/**
+ * title: Basic usage
+ * desc: Persist state into IndexedDB
+ *
+ * title.zh-CN: 基础用法
+ * desc.zh-CN: 将状态持久化存储到 IndexedDB 中
+ */
+
+import React from 'react';
+import useIndexDBState from '../index';
+
+export default function Demo() {
+  const [message, setMessage] = useIndexDBState<string>('message', {
+    defaultValue: 'Hello',
+  });
+
+  return (
+    <>
+      <input
+        value={message || ''}
+        placeholder="Please enter some text"
+        onChange={(e) => setMessage(e.target.value)}
+        style={{ width: 200, marginRight: 16 }}
+      />
+      <button
+        type="button"
+        onClick={() => setMessage(undefined)}
+        style={{ marginRight: 16 }}
+      >
+        Reset
+      </button>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+      >
+        Refresh
+      </button>
+    </>
+  );
+} 

--- a/packages/hooks/src/useIndexDBState/demo/demo2.tsx
+++ b/packages/hooks/src/useIndexDBState/demo/demo2.tsx
@@ -1,0 +1,76 @@
+/**
+ * title: Store complex object
+ * desc: useIndexDBState can store complex objects
+ *
+ * title.zh-CN: 存储复杂对象
+ * desc.zh-CN: useIndexDBState 可以存储复杂对象
+ */
+
+import React, { useState } from 'react';
+import useIndexDBState from '../index';
+
+interface User {
+  name: string;
+  age: number;
+}
+
+export default function Demo() {
+  const [user, setUser] = useIndexDBState<User>('user', {
+    defaultValue: { name: 'Ahooks', age: 1 },
+  });
+
+  const [inputValue, setInputValue] = useState('');
+  const [inputAge, setInputAge] = useState('');
+
+  return (
+    <>
+      <div>
+        <label>Name: </label>
+        <input
+          value={inputValue}
+          placeholder="Please enter name"
+          onChange={(e) => setInputValue(e.target.value)}
+          style={{ width: 200, marginRight: 16 }}
+        />
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <label>Age: </label>
+        <input
+          value={inputAge}
+          placeholder="Please enter age"
+          onChange={(e) => setInputAge(e.target.value)}
+          style={{ width: 200, marginRight: 16 }}
+        />
+      </div>
+      <div style={{ marginTop: 16 }}>
+        <button
+          type="button"
+          onClick={() => {
+            setUser({ name: inputValue, age: Number(inputAge) });
+            setInputValue('');
+            setInputAge('');
+          }}
+          style={{ marginRight: 16 }}
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={() => setUser(undefined)}
+          style={{ marginRight: 16 }}
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+        >
+          Refresh
+        </button>
+      </div>
+      <div style={{ marginTop: 16 }}>
+        <pre>{JSON.stringify(user, null, 2)}</pre>
+      </div>
+    </>
+  );
+} 

--- a/packages/hooks/src/useIndexDBState/index.en-US.md
+++ b/packages/hooks/src/useIndexDBState/index.en-US.md
@@ -1,0 +1,58 @@
+---
+nav:
+  path: /hooks
+---
+
+# useIndexDBState
+
+A Hook that stores state into IndexedDB.
+
+## Examples
+
+### Basic usage
+
+<code src="./demo/demo1.tsx" />
+
+### Complex object
+
+<code src="./demo/demo2.tsx" />
+
+## API
+
+```typescript
+type SetState<S> = S | ((prevState?: S) => S);
+
+interface Options<T> {
+  defaultValue?: T | (() => T);
+  dbName?: string;
+  storeName?: string;
+  version?: number;
+  onError?: (error: unknown) => void;
+}
+
+const [state, setState] = useIndexDBState<T>(key: string, options?: Options<T>);
+```
+
+### Params
+
+| Property | Description | Type | Default |
+|----------|-------------|------|---------|
+| key | The key of the IndexedDB record | `string` | - |
+| options | Optional configuration | `Options` | - |
+
+### Options
+
+| Property | Description | Type | Default |
+|----------|-------------|------|---------|
+| defaultValue | Default value | `T \| (() => T)` | `undefined` |
+| dbName | Name of the IndexedDB database | `string` | `ahooks-indexdb` |
+| storeName | Name of the object store | `string` | `ahooks-store` |
+| version | Version of the database | `number` | `1` |
+| onError | Error handler | `(error: unknown) => void` | `(e) => console.error(e)` |
+
+### Result
+
+| Property | Description | Type |
+|----------|-------------|------|
+| state | Current state | `T` |
+| setState | Set state | `(value?: SetState<T>) => void` | 

--- a/packages/hooks/src/useIndexDBState/index.ts
+++ b/packages/hooks/src/useIndexDBState/index.ts
@@ -1,0 +1,158 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import useMemoizedFn from '../useMemoizedFn';
+import { isFunction } from '../utils';
+import isBrowser from '../utils/isBrowser';
+
+export type SetState<S> = S | ((prevState?: S) => S);
+
+export interface Options<T> {
+  defaultValue?: T | (() => T);
+  dbName?: string;
+  storeName?: string;
+  version?: number;
+  onError?: (error: unknown) => void;
+}
+
+function useIndexDBState<T>(key: string, options: Options<T> = {}) {
+  const {
+    defaultValue,
+    dbName = 'ahooks-indexdb',
+    storeName = 'ahooks-store',
+    version = 1,
+    onError = (e) => {
+      console.error(e);
+    },
+  } = options;
+
+  const [state, setState] = useState<T | undefined>(() => {
+    if (isFunction(defaultValue)) {
+      return defaultValue();
+    }
+    return defaultValue;
+  });
+
+  const dbRef = useRef<IDBDatabase | null>(null);
+  const initialized = useRef<boolean>(false);
+
+  // 从 IndexDB 获取数据
+  const getValueFromDB = async (k: string): Promise<T | undefined> => {
+    return new Promise((resolve, reject) => {
+      if (!dbRef.current) {
+        resolve(undefined);
+        return;
+      }
+
+      try {
+        const transaction = dbRef.current.transaction(storeName, 'readonly');
+        const store = transaction.objectStore(storeName);
+        const request = store.get(k);
+
+        request.onsuccess = () => {
+          resolve(request.result);
+        };
+
+        request.onerror = (event) => {
+          onError(event);
+          reject(event);
+        };
+      } catch (error) {
+        onError(error);
+        reject(error);
+      }
+    });
+  };
+
+  // 更新 IndexDB 中的数据
+  const updateValueInDB = async (k: string, value: T | undefined) => {
+    return new Promise<void>((resolve, reject) => {
+      if (!dbRef.current) {
+        reject(new Error('Database not initialized'));
+        return;
+      }
+
+      try {
+        const transaction = dbRef.current.transaction(storeName, 'readwrite');
+        const store = transaction.objectStore(storeName);
+        let request;
+
+        if (value === undefined) {
+          request = store.delete(k);
+        } else {
+          request = store.put(value, k);
+        }
+
+        request.onsuccess = () => {
+          resolve();
+        };
+
+        request.onerror = (event) => {
+          onError(event);
+          reject(event);
+        };
+      } catch (error) {
+        onError(error);
+        reject(error);
+      }
+    });
+  };
+
+  // 初始化 IndexDB
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    const initDB = () => {
+      const request = window.indexedDB.open(dbName, version);
+
+      request.onerror = (event) => {
+        onError(event);
+      };
+
+      request.onsuccess = (event) => {
+        dbRef.current = (event.target as IDBOpenDBRequest).result;
+        // 初始化完成后，尝试获取数据
+        getValueFromDB(key).then((value) => {
+          if (value !== undefined) {
+            setState(value);
+          }
+          initialized.current = true;
+        });
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName);
+        }
+      };
+    };
+
+    if (typeof window !== 'undefined' && window.indexedDB) {
+      initDB();
+    } else {
+      onError(new Error('IndexedDB is not supported in this environment'));
+    }
+
+    return () => {
+      if (dbRef.current) {
+        dbRef.current.close();
+        dbRef.current = null;
+      }
+    };
+  }, [dbName, storeName, version, key, onError]);
+
+  // 更新状态
+  const updateState = useCallback((value?: SetState<T>) => {
+    const currentState = isFunction(value) ? value(state) : value;
+    setState(currentState);
+
+    if (initialized.current && isBrowser) {
+      updateValueInDB(key, currentState).catch(onError);
+    }
+  }, [state, key, onError]);
+
+  return [state, useMemoizedFn(updateState)] as const;
+}
+
+export default useIndexDBState; 

--- a/packages/hooks/src/useIndexDBState/index.zh-CN.md
+++ b/packages/hooks/src/useIndexDBState/index.zh-CN.md
@@ -1,0 +1,58 @@
+---
+nav:
+  path: /hooks
+---
+
+# useIndexDBState
+
+一个可以将状态持久化存储到 IndexedDB 中的 Hook。
+
+## 代码演示
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+### 存储复杂对象
+
+<code src="./demo/demo2.tsx" />
+
+## API
+
+```typescript
+type SetState<S> = S | ((prevState?: S) => S);
+
+interface Options<T> {
+  defaultValue?: T | (() => T);
+  dbName?: string;
+  storeName?: string;
+  version?: number;
+  onError?: (error: unknown) => void;
+}
+
+const [state, setState] = useIndexDBState<T>(key: string, options?: Options<T>);
+```
+
+### Params
+
+| 参数    | 说明                          | 类型     | 默认值 |
+|---------|-------------------------------|----------|--------|
+| key     | 存储在 IndexedDB 中的键名     | `string` | -      |
+| options | 可选配置项                    | `Options`| -      |
+
+### Options
+
+| 参数         | 说明                              | 类型                      | 默认值                  |
+|--------------|-----------------------------------|---------------------------|-------------------------|
+| defaultValue | 默认值                            | `T \| (() => T)`          | `undefined`             |
+| dbName       | IndexedDB 数据库名称              | `string`                  | `ahooks-indexdb`        |
+| storeName    | 对象存储空间名称                  | `string`                  | `ahooks-store`          |
+| version      | 数据库版本                        | `number`                  | `1`                     |
+| onError      | 错误处理函数                      | `(error: unknown) => void`| `(e) => console.error(e)` |
+
+### Result
+
+| 参数     | 说明                    | 类型                           |
+|----------|-------------------------|--------------------------------|
+| state    | 当前状态                | `T`                            |
+| setState | 设置状态的函数          | `(value?: SetState<T>) => void`| 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

IndexedDB 是浏览器提供的一种客户端存储方案，相比 localStorage 和 sessionStorage，它可以存储更大量的结构化数据。目前 ahooks 已经提供了 useLocalStorageState 和 useSessionStorageState，但还没有提供 IndexedDB 相关的 hook。

这个 PR 添加了 useIndexDBState hook，它可以将 React 状态持久化存储到 IndexedDB 中，并提供了类似于 useState 的 API，使用简单。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `useIndexDBState` hook to persist state into IndexedDB. |
| 🇨🇳 Chinese | 添加 `useIndexDBState` hook，用于将状态持久化存储到 IndexedDB 中。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed