### PR TITLE
feat(useFavicon): Allow additional dependency list for `useFavicon()` hook

### DIFF
--- a/packages/hooks/src/useFavicon/index.ts
+++ b/packages/hooks/src/useFavicon/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 const ImgTypeMap = {
   SVG: 'image/svg+xml',
@@ -9,7 +9,7 @@ const ImgTypeMap = {
 
 type ImgTypes = keyof typeof ImgTypeMap;
 
-const useFavicon = (href: string) => {
+const useFavicon = (href: string, deps?: React.DependencyList) => {
   useEffect(() => {
     if (!href) return;
 
@@ -24,7 +24,7 @@ const useFavicon = (href: string) => {
     link.rel = 'shortcut icon';
 
     document.getElementsByTagName('head')[0].appendChild(link);
-  }, [href]);
+  }, [href, ...(deps ?? [])]);
 };
 
 export default useFavicon;


### PR DESCRIPTION
Hello, ahooks team!

First of all, thanks for maintaining this project.

### 🤔 This is a ...

- [x] New feature

### 💡 Background and solution

I have encountered several cases where the favicon doesn't update when the source URL changes. This pull request addresses that issue by allowing an additional `deps?: React.DependencyList` argument for the `useFavicon()` hook. This enhancement ensures that the favicon updates properly when the dependencies change.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow additional `deps?: React.DependencyList` argument for the `useFavicon()` hook. |
| 🇨🇳 Chinese | 允许为 useFavicon() hook 添加额外的 deps?: React.DependencyList 参数。(Translated by ChatGPT) |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed

I appreciate your feedback in advance.
