### PR TITLE
feat(use-url-state): 支持react router v7

### DIFF
--- a/packages/use-url-state/package.json
+++ b/packages/use-url-state/package.json
@@ -6,12 +6,7 @@
   "module": "./es/index.js",
   "types": "./lib/index.d.ts",
   "unpkg": "dist/ahooks-use-url-state.js",
-  "files": [
-    "dist",
-    "lib",
-    "es",
-    "package.json"
-  ],
+  "files": ["dist", "lib", "es", "package.json"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alibaba/hooks.git"
@@ -29,7 +24,7 @@
   "homepage": "https://github.com/alibaba/hooks",
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-router": "^5.0.0 || ^6.0.0"
+    "react-router": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.21.0",

--- a/packages/use-url-state/package.json
+++ b/packages/use-url-state/package.json
@@ -1,12 +1,17 @@
 {
   "name": "@ahooksjs/use-url-state",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "A hook that stores the state into url query parameters.",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "types": "./lib/index.d.ts",
   "unpkg": "dist/ahooks-use-url-state.js",
-  "files": ["dist", "lib", "es", "package.json"],
+  "files": [
+    "dist",
+    "lib",
+    "es",
+    "package.json"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alibaba/hooks.git"

--- a/packages/use-url-state/src/index.ts
+++ b/packages/use-url-state/src/index.ts
@@ -40,7 +40,7 @@ const useUrlState = <S extends UrlState = UrlState>(
 
   // react-router v5
   const history = rc.useHistory?.();
-  // react-router v6
+  // react-router v6&v7
   const navigate = rc.useNavigate?.();
 
   const update = useUpdate();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,7 +217,7 @@ importers:
         specifier: ^16.8.0 || ^17.0.0 || ^18.0.0
         version: 18.3.1
       react-router:
-        specifier: ^5.0.0 || ^6.0.0
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
         version: 6.26.1(react@18.3.1)
       tslib:
         specifier: ^2.4.1
@@ -1044,28 +1044,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.8.3':
     resolution: {integrity: sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.8.3':
     resolution: {integrity: sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.8.3':
     resolution: {integrity: sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.8.3':
     resolution: {integrity: sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==}
@@ -3823,7 +3819,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

### 🤔 这个变动的性质是？

- [x] 其他改动（添加对react-router v7支持）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
我在开发自己项目的时候使用了最新的react-router v7，版本号为7.3.0，同时用到了useUrlState这个hook，调研之后发现该hook主要使用了useNavigate useLocation这两个hook，而相比于react router v6，v7版本并未对这两个hook做出改动，可以直接复用，只需要添加peer依赖对react-router v7的支持即可。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add support for react-router v7, no code changes. If react-router v7 does not modify the useLocation and useNavigate APIs in later versions, there is no risk. |
| 🇨🇳 中文 | 添加对react-router v7的支持，未改动代码，若react-router v7在之后的版本未对useLocation和useNavigate的api进行修改，则无风险 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
