### PR TITLE
refactor(useMemoizedFn): 将useMemo替换为useEffect来更新fnRef.current

### DIFF
--- a/packages/hooks/src/useMemoizedFn/index.ts
+++ b/packages/hooks/src/useMemoizedFn/index.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { isFunction } from '../utils';
 import isDev from '../utils/isDev';
 
@@ -20,7 +20,9 @@ function useMemoizedFn<T extends noop>(fn: T) {
 
   // why not write `fnRef.current = fn`?
   // https://github.com/alibaba/hooks/issues/728
-  fnRef.current = useMemo<T>(() => fn, [fn]);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
 
   const memoizedFn = useRef<PickFunction<T>>();
   if (!memoizedFn.current) {


### PR DESCRIPTION
使用useMemo来更新fnRef.current，虽然没问题，但本质还是在 render 阶段做副作用，副作用交给 useEffect 来处理，能更安全可靠。
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | refactor: Replace useMemo with useEffect|
| 🇨🇳 中文 | refactor: Replace useMemo with useEffect|

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
