### PR TITLE
fix: 修复 useInfiniteScroll 时序竞争问题

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -90,10 +90,15 @@ const useInfiniteScroll = <TData extends Data>(
     run(finalData);
   });
 
+  const runAsyncForCurrent = async () => {
+    const res = await runAsync(finalData);
+    return res.currentData
+  }
+
   const loadMoreAsync = useMemoizedFn(() => {
     if (noMore) return Promise.reject();
     setLoadingMore(true);
-    return runAsync(finalData);
+    return runAsyncForCurrent()
   });
 
   const reload = () => {
@@ -103,7 +108,7 @@ const useInfiniteScroll = <TData extends Data>(
 
   const reloadAsync = () => {
     setLoadingMore(false);
-    return runAsync();
+    return runAsyncForCurrent()
   };
 
   const scrollMethod = () => {

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -40,29 +40,30 @@ const useInfiniteScroll = <TData extends Data>(
   const { loading, error, run, runAsync, cancel } = useRequest(
     async (lastData?: TData) => {
       const currentData = await service(lastData);
-      if (!lastData) {
-        setFinalData({
-          ...currentData,
-          list: [...(currentData.list ?? [])],
-        });
-      } else {
-        setFinalData({
-          ...currentData,
-          list: isScrollToTop
-            ? [...currentData.list, ...(lastData.list ?? [])]
-            : [...(lastData.list ?? []), ...currentData.list],
-        });
-      }
-      return currentData;
+      return { currentData, lastData };
     },
     {
       manual,
       onFinally: (_, d, e) => {
         setLoadingMore(false);
-        onFinally?.(d, e);
+        onFinally?.(d?.currentData, e);
       },
       onBefore: () => onBefore?.(),
       onSuccess: (d) => {
+        if (!d.lastData) {
+          setFinalData({
+            ...d.currentData,
+            list: [...(d.currentData.list ?? [])],
+          });
+        } else {
+          setFinalData({
+            ...d.currentData,
+            list: isScrollToTop
+              ? [...d.currentData.list, ...(d.lastData.list ?? [])]
+              : [...(d.lastData.list ?? []), ...d.currentData.list],
+          });
+        }
+
         setTimeout(() => {
           if (isScrollToTop) {
             let el = getTargetElement(target);
@@ -77,7 +78,7 @@ const useInfiniteScroll = <TData extends Data>(
           }
         });
 
-        onSuccess?.(d);
+        onSuccess?.(d.currentData);
       },
       onError: (e) => onError?.(e),
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/alibaba/hooks/issues/2767
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | useInfiniteScroll update inner finalData state with useRequest  onSuccess callback to avoid temporal competition |
| 🇨🇳 中文 | useInfiniteScroll 使用 useRequest 的 onSuccess 回调更新内部 finalData state 来避免时序竞争问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供