### PR TITLE
docs: add new usage example for useBoolean hook

### DIFF
--- a/example/.gitkeep
+++ b/example/.gitkeep
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useBoolean } from 'ahooks';
+
+export default function Demo() {
+  const [state, { toggle, setTrue, setFalse }] = useBoolean(false);
+
+  return (
+    <div>
+      <p>Current state: {state ? 'ON' : 'OFF'}</p>
+      <button onClick={toggle}>Toggle</button>
+      <button onClick={setTrue}>Set True</button>
+      <button onClick={setFalse}>Set False</button>
+    </div>
+  );
+}


### PR DESCRIPTION
### What I did
Added a simple usage example of `useBoolean` hook in the documentation.  
The example demonstrates:
- Initializing a boolean state
- Toggling state between true/false
- Explicitly setting state to true or false

### Why this change
- Makes it easier for beginners to quickly understand how to use `useBoolean`
- Provides a copy-paste ready example
- Improves the overall readability and usability of the documentation

### Example
```tsx
import React from 'react';
import { useBoolean } from 'ahooks';

export default function Demo() {
  const [state, { toggle, setTrue, setFalse }] = useBoolean(false);

  return (
    <div>
      <p>Current state: {state ? 'ON ✅' : 'OFF ❌'}</p>
      <button onClick={toggle}>Toggle</button>
      <button onClick={setTrue}>Set True</button>
      <button onClick={setFalse}>Set False</button>
    </div>
  );
}
