### PR TITLE
refactor(useUrlState): rename initialState to baseState

### DIFF
--- a/packages/use-url-state/__tests__/setup.tsx
+++ b/packages/use-url-state/__tests__/setup.tsx
@@ -7,13 +7,13 @@ import { expect, test } from 'vitest';
 
 export const setup = (
   initialEntries: MemoryRouterProps['initialEntries'],
-  initialState: any = {},
+  baseState: any = {},
   options?: Options,
 ) => {
   const res = {} as any;
 
   const Component = () => {
-    const [state, setState] = useUrlState(initialState, options);
+    const [state, setState] = useUrlState(baseState, options);
     const location = useLocation();
     Object.assign(res, { state, setState, location });
     return null;

--- a/packages/use-url-state/src/index.ts
+++ b/packages/use-url-state/src/index.ts
@@ -27,7 +27,7 @@ const baseStringifyConfig: StringifyOptions = {
 type UrlState = Record<string, any>;
 
 const useUrlState = <S extends UrlState = UrlState>(
-  initialState?: S | (() => S),
+  baseState?: S | (() => S),
   options?: Options,
 ) => {
   type State = Partial<{
@@ -52,8 +52,8 @@ const useUrlState = <S extends UrlState = UrlState>(
 
   const update = useUpdate();
 
-  const initialStateRef = useRef(
-    typeof initialState === 'function' ? initialState() : initialState || {},
+  const baseStateRef = useRef(
+    typeof baseState === 'function' ? baseState() : baseState || {},
   );
 
   const queryFromUrl = useMemo(() => {
@@ -62,7 +62,7 @@ const useUrlState = <S extends UrlState = UrlState>(
 
   const targetQuery = useMemo<State>(
     () => ({
-      ...initialStateRef.current,
+      ...baseStateRef.current,
       ...queryFromUrl,
     }),
     [queryFromUrl],

--- a/packages/use-url-state/use-url-state.en-US.md
+++ b/packages/use-url-state/use-url-state.en-US.md
@@ -54,15 +54,15 @@ React Router V6: https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 ## API
 
 ```typescript
-const [state, setState] = useUrlState(initialState, options);
+const [state, setState] = useUrlState(baseState, options);
 ```
 
 ### Params
 
-| Property     | Description                    | Type           | Default |
-| ------------ | ------------------------------ | -------------- | ------- |
-| initialState | InitialState, same as useState | `S \| () => S` | -       |
-| options      | Url config                     | `Options`      | -       |
+| Property  | Description                                                                                    | Type           | Default |
+| --------- | ---------------------------------------------------------------------------------------------- | -------------- | ------- |
+| baseState | URL search params will be merged into BaseState | `S \| () => S` | -       |
+| options   | Url config                                                                                     | `Options`      | -       |
 
 ### Options
 

--- a/packages/use-url-state/use-url-state.zh-CN.md
+++ b/packages/use-url-state/use-url-state.zh-CN.md
@@ -54,15 +54,15 @@ React Router V6: https://codesandbox.io/s/autumn-shape-odrt9?file=/App.tsx
 ## API
 
 ```typescript
-const [state, setState] = useUrlState(initialState, options);
+const [state, setState] = useUrlState(baseState, options);
 ```
 
 ### Params
 
-| 参数         | 说明     | 类型           | 默认值 |
-| ------------ | -------- | -------------- | ------ |
-| initialState | 初始状态 | `S \| () => S` | -      |
-| options      | url 配置 | `Options`      | -      |
+| 参数      | 说明                                                           | 类型           | 默认值 |
+| --------- | -------------------------------------------------------------- | -------------- | ------ |
+| baseState | 基准状态，URL 查询参数会在此基础上进行合并 | `S \| () => S` | -      |
+| options   | url 配置                                                       | `Options`      | -      |
 
 ### Options
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [x] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #2842

### 💡 需求背景和解决方案

`useUrlState` 钩子的参数 `initialState` 语义容易被误解为「默认值」，但实际内部逻辑是作为基准值（base），每次 URL 查询参数都会 merge 到它上面。

本次修改将参数重命名为 `baseState`，同时更新内部变量命名 (`initialStateRef` → `baseStateRef`)。  
文档示例、中文和英文说明也已同步修改。  

> 这个改动不会破坏现有调用，因为参数位置未改变，仅做语义优化。

最终 API 使用示例：

```ts
const [state, setState] = useUrlState(baseState, options);
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Rename `initialState` to `baseState` in `useUrlState` for clearer semantics. Updated internal variable names and documentation. |
| 🇨🇳 中文 | 将 `useUrlState` 的参数 `initialState` 改名为 `baseState`，更新内部变量和文档以明确语义。 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供