### PR TITLE
feat:Add `useClipboard` hook with clipboard management and tests

### DIFF
--- a/packages/hooks/src/useClipboard/__tests__/index.spec.ts
+++ b/packages/hooks/src/useClipboard/__tests__/index.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useClipboard from '../index';
+
+// 模拟 ClipboardItem
+class MockClipboardItem {
+  constructor(public items: Record<string, Blob>) {}
+
+  get types() {
+    return Object.keys(this.items);
+  }
+
+  async getType(type: string): Promise<Blob> {
+    const blob = this.items[type];
+    if (!blob) {
+      throw new Error(`Type ${type} not found`);
+    }
+    return blob;
+  }
+
+  static supports = vi.fn().mockReturnValue(true);
+}
+
+// 全局模拟
+
+global.ClipboardItem = MockClipboardItem as any;
+
+global.Blob = class MockBlob {
+  constructor(public content: string[], public options: { type: string }) {}
+  async text(): Promise<string> {
+    return this.content.join('');
+  }
+} as any;
+
+// 模拟 btoa 和 atob
+
+global.btoa = vi.fn((str: string) => Buffer.from(str, 'binary').toString('base64'));
+
+global.atob = vi.fn((str: string) => Buffer.from(str, 'base64').toString('binary'));
+
+describe('useClipboard', () => {
+  let mockClipboard: {
+    write: ReturnType<typeof vi.fn>;
+    read: ReturnType<typeof vi.fn>;
+    readText: ReturnType<typeof vi.fn>;
+  };
+
+  let mockPermissions: {
+    query: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClipboard = {
+      write: vi.fn(),
+      read: vi.fn(),
+      readText: vi.fn(),
+    };
+
+    mockPermissions = {
+      query: vi.fn(),
+    };
+
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: mockClipboard,
+      configurable: true,
+    });
+
+    Object.defineProperty(window.navigator, 'permissions', {
+      value: mockPermissions,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isSupported', () => {
+    it('should return true when clipboard API is available in secure context', () => {
+      const { result } = renderHook(() => useClipboard());
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it('should return false when not in secure context', () => {
+      Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+      const { result } = renderHook(() => useClipboard());
+      expect(result.current.isSupported).toBe(false);
+    });
+
+    it('should return false when clipboard API is not available', () => {
+      // 删除属性而不是设为 undefined
+      // @ts-expect-error
+      delete window.navigator.clipboard;
+      const { result } = renderHook(() => useClipboard());
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  describe('hasPermission', () => {
+    it('should return true when both read and write permissions are granted', async () => {
+      mockPermissions.query.mockResolvedValueOnce({ state: 'granted' });
+      mockPermissions.query.mockResolvedValueOnce({ state: 'granted' });
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        const hasPermission = await result.current.hasPermission();
+        expect(hasPermission).toBe(true);
+      });
+    });
+
+    it('should return false when write permission is denied', async () => {
+      mockPermissions.query.mockResolvedValueOnce({ state: 'denied' });
+      mockPermissions.query.mockResolvedValueOnce({ state: 'granted' });
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        const hasPermission = await result.current.hasPermission();
+        expect(hasPermission).toBe(false);
+      });
+    });
+
+    it('should fallback to readText test when permissions API fails', async () => {
+      mockPermissions.query.mockRejectedValue(new Error('Permissions API not available'));
+      mockClipboard.readText.mockResolvedValue('test');
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        const hasPermission = await result.current.hasPermission();
+        expect(hasPermission).toBe(true);
+      });
+    });
+
+    it('should return false when not supported', async () => {
+      // @ts-expect-error
+      delete window.navigator.clipboard;
+      // @ts-expect-error
+      delete window.navigator.permissions;
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        const hasPermission = await result.current.hasPermission();
+        expect(hasPermission).toBe(false);
+      });
+    });
+  });
+
+  describe('copy', () => {
+    it('should successfully copy simple data with HTML support', async () => {
+      mockClipboard.write.mockResolvedValue(undefined);
+      MockClipboardItem.supports.mockReturnValue(true);
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        await result.current.copy('Test display text', { id: 1 });
+      });
+      expect(mockClipboard.write).toHaveBeenCalled();
+    });
+
+    it('should throw error when not supported', async () => {
+      // @ts-expect-error
+      delete window.navigator.clipboard;
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        await expect(result.current.copy('test', { data: 'test' }))
+          .rejects.toThrow('Clipboard API is not supported in this environment');
+      });
+    });
+  });
+
+  describe('paste', () => {
+    it('should return null when clipboard is empty', async () => {
+      mockClipboard.read.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        const pasted = await result.current.paste();
+        expect(pasted).toBeNull();
+      });
+    });
+
+    it('should throw error when not supported', async () => {
+      // @ts-expect-error
+      delete window.navigator.clipboard;
+
+      const { result } = renderHook(() => useClipboard());
+      await act(async () => {
+        await expect(result.current.paste())
+          .rejects.toThrow('Clipboard API is not supported in this environment');
+      });
+    });
+  });
+});

--- a/packages/hooks/src/useClipboard/demo/demo1.tsx
+++ b/packages/hooks/src/useClipboard/demo/demo1.tsx
@@ -116,10 +116,10 @@ const Demo1: React.FC = () => {
         </Card>
 
         <Button type='primary' onClick={() => handlePaste()}>
-          CopyDisplayText
+          Paste(DisplayText)
         </Button>
         <Button type='primary' onClick={() => handlePaste(true)}>
-          CopyData
+          Paste(Data)
         </Button>
         {/* 显示粘贴的数据 */}
         {pastedData && (

--- a/packages/hooks/src/useClipboard/demo/demo1.tsx
+++ b/packages/hooks/src/useClipboard/demo/demo1.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import { Button, Card, Input, message, Space, Typography } from 'antd';
+import { FileTextOutlined, UserOutlined } from '@ant-design/icons';
+import useClipboard from '../index';
+
+const { TextArea } = Input;
+const { Text } = Typography;
+
+interface UserInfo {
+  id: number;
+  name: string;
+  email: string;
+  age: number;
+  address: {
+    city: string;
+    district: string;
+  };
+}
+
+const Demo1: React.FC = () => {
+  const [pastedData, setPastedData] = useState<any>(null);
+  const { copy, paste, isSupported } = useClipboard();
+
+  // 示例数据
+  const userInfo: UserInfo = {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    age: 28,
+    address: {
+      city: 'Beijing',
+      district: 'Haidian District',
+    },
+  };
+  const configObject = {
+    theme: 'dark',
+    language: 'zh-CN',
+    features: {
+      clipboard: true,
+      notifications: false,
+      autoSave: true,
+    },
+    lastModified: new Date().toISOString(),
+  };
+
+  const handleCopyData = async (data: any, displayText: string) => {
+    try {
+      await copy(displayText, data);
+      message.success(`${displayText} 复制成功！`);
+    } catch (error:any) {
+      message.error(`复制失败: ${error?.message}`);
+    }
+  };
+
+  const handlePaste = async (showDisplayText?: boolean) => {
+    try {
+      const data = showDisplayText ? await paste() : await navigator.clipboard.readText();
+      setPastedData(data);
+      if (data) {
+        message.success('粘贴成功！');
+      } else {
+        message.info('剪贴板为空');
+      }
+    } catch (error:any) {
+      message.error(`粘贴失败: ${error?.message}`);
+    }
+  };
+
+  if (!isSupported) {
+    return (
+      <div style={{ padding: '20px', color: '#ff4d4f' }}>
+        Clipboard API is not supported in the current environment
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <Space direction='vertical' size='large' style={{ width: '100%' }}>
+        {/* 用户信息 */}
+        <Card
+          size='small'
+          title={
+            <>
+              <UserOutlined /> displayText:UserInfo
+            </>
+          }
+        >
+          <pre style={{ fontSize: '12px', margin: 0 }}>{JSON.stringify(userInfo, null, 2)}</pre>
+          <Button
+            size='small'
+            style={{ marginTop: '8px' }}
+            onClick={() => handleCopyData(userInfo, 'UserInfo')}
+          >
+            Copy
+          </Button>
+        </Card>
+
+        {/* 配置对象 */}
+        <Card
+          size='small'
+          title={
+            <>
+              <FileTextOutlined /> displayText:ConfigObject
+            </>
+          }
+        >
+          <pre style={{ fontSize: '12px', margin: 0 }}>{JSON.stringify(configObject, null, 2)}</pre>
+          <Button
+            size='small'
+            style={{ marginTop: '8px' }}
+            onClick={() => handleCopyData(configObject, 'ConfigObject')}
+          >
+            Copy
+          </Button>
+        </Card>
+
+        <Button type='primary' onClick={() => handlePaste()}>
+          CopyDisplayText
+        </Button>
+        <Button type='primary' onClick={() => handlePaste(true)}>
+          CopyData
+        </Button>
+        {/* 显示粘贴的数据 */}
+        {pastedData && (
+          <Card title='Paste content' size='small'>
+            <div style={{ marginBottom: '8px' }}>
+              <Text strong>Data Type: </Text>
+              <Text code>{typeof pastedData}</Text>
+            </div>
+            <TextArea
+              value={
+                typeof pastedData === 'string' ? pastedData : JSON.stringify(pastedData, null, 2)
+              }
+              rows={8}
+              readOnly
+            />
+          </Card>
+        )}
+      </Space>
+    </div>
+  );
+};
+
+export default Demo1;

--- a/packages/hooks/src/useClipboard/demo/demo2.tsx
+++ b/packages/hooks/src/useClipboard/demo/demo2.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+import { Alert, Badge, Button, Card, Divider, Space, Typography } from 'antd';
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ExclamationCircleOutlined,
+} from '@ant-design/icons';
+import useClipboard from '../index';
+import useAsyncEffect from '../../useAsyncEffect';
+
+const { Text } = Typography;
+
+interface ErrorInfo {
+  code: string;
+  message: string;
+  timestamp: Date;
+}
+
+const Demo2: React.FC = () => {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [errors, setErrors] = useState<ErrorInfo[]>([]);
+  const [isChecking, setIsChecking] = useState(false);
+  const { copy, isSupported, hasPermission: checkPermission } = useClipboard();
+
+  const addError = (code: string, message: string) => {
+    const errorInfo: ErrorInfo = {
+      code,
+      message,
+      timestamp: new Date(),
+    };
+    setErrors((prev) => [errorInfo, ...prev.slice(0, 4)]); // 只保留最近5个错误
+  };
+  const checkClipboardPermission = async () => {
+    setIsChecking(true);
+    try {
+      const permission = await checkPermission();
+      console.log('[demo3]>>checkClipboardPermission>>permission:', permission);
+      setHasPermission(permission);
+    } catch (error:any) {
+      addError('PERMISSION_CHECK_FAILED', error?.message);
+      setHasPermission(false);
+    } finally {
+      setIsChecking(false);
+    }
+  };
+  useAsyncEffect(async () => {
+    await checkClipboardPermission();
+  }, []);
+
+  const handleCopyWithError = async (scenario: string) => {
+    try {
+      switch (scenario) {
+        case 'empty_text':
+          await copy('', { data: 'test' });
+          break;
+        case 'large_data':
+          const largeData = 'x'.repeat(2 * 1024 * 1024); // 2MB 数据
+          await copy('Large Data', largeData);
+          break;
+        case 'null_data':
+          await copy('Null Data', null);
+          break;
+        case 'normal':
+          await copy('测试数据', { message: '这是一个正常的复制操作' });
+          break;
+      }
+    } catch (error:any) {
+      if (error?.code) {
+        addError(error?.code, error?.message);
+      } else {
+        addError('UNKNOWN_ERROR', error?.message);
+      }
+    }
+  };
+
+  const getPermissionStatus = () => {
+    if (hasPermission === null) {
+      return { status: 'processing', text: 'checking...', icon: <ExclamationCircleOutlined /> };
+    }
+    if (hasPermission) {
+      return { status: 'success', text: 'granted', icon: <CheckCircleOutlined /> };
+    }
+    return { status: 'error', text: 'denied', icon: <CloseCircleOutlined /> };
+  };
+
+  const getErrorTypeColor = (code: string) => {
+    switch (code) {
+      case 'PERMISSION_DENIED':
+        return 'warning';
+      case 'UNSUPPORTED':
+        return 'error';
+      case 'INVALID_INPUT':
+        return 'default';
+      case 'DATA_TOO_LARGE':
+        return 'orange';
+      default:
+        return 'red';
+    }
+  };
+
+  if (!isSupported) {
+    return (
+      <Alert
+        message='Environment not supported'
+        description='Clipboard API is not supported in current environment, please use it in HTTPS environment or localhost.'
+        type='error'
+        showIcon
+      />
+    );
+  }
+
+  const permissionStatus = getPermissionStatus();
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <Space direction='vertical' size='large' style={{ width: '100%' }}>
+        {/* 权限状态 */}
+        <Card size='small' title='Clipboard permission status'>
+          <Space>
+            <Badge
+              status={permissionStatus.status as any}
+              text={
+                <Text>
+                  {permissionStatus.icon} {permissionStatus.text}
+                </Text>
+              }
+            />
+            <Button size='small' loading={isChecking} onClick={checkClipboardPermission}>
+              rechecking
+            </Button>
+          </Space>
+        </Card>
+
+        {/* 错误测试 */}
+        <Card size='small' title='Error scenario testing'>
+          <Space wrap>
+            <Button size='small' onClick={() => handleCopyWithError('empty_text')}>
+              Empty text error
+            </Button>
+            <Button size='small' onClick={() => handleCopyWithError('large_data')}>
+              Too large data error
+            </Button>
+            <Button size='small' onClick={() => handleCopyWithError('null_data')}>
+              Empty data error
+            </Button>
+          </Space>
+        </Card>
+
+        {/* 错误历史 */}
+        {errors.length > 0 && (
+          <Card
+            size='small'
+            title='Error history'
+            extra={
+              <Button size='small' onClick={() => setErrors([])}>
+                Clear
+              </Button>
+            }
+          >
+            <Space direction='vertical' style={{ width: '100%' }}>
+              {errors.map((error, index) => (
+                <div key={index}>
+                  <Space>
+                    <Badge color={getErrorTypeColor(error.code)} />
+                    <Text code>{error.code}</Text>
+                    <Text type='secondary'>{error.timestamp.toLocaleTimeString()}</Text>
+                  </Space>
+                  <div style={{ marginTop: '4px', marginLeft: '20px' }}>
+                    <Text type='danger'>{error.message}</Text>
+                  </div>
+                  {index < errors.length - 1 && <Divider style={{ margin: '8px 0' }} />}
+                </div>
+              ))}
+            </Space>
+          </Card>
+        )}
+      </Space>
+    </div>
+  );
+};
+
+export default Demo2;

--- a/packages/hooks/src/useClipboard/demo/demo2.tsx
+++ b/packages/hooks/src/useClipboard/demo/demo2.tsx
@@ -34,7 +34,7 @@ const Demo2: React.FC = () => {
     setIsChecking(true);
     try {
       const permission = await checkPermission();
-      console.log('[demo3]>>checkClipboardPermission>>permission:', permission);
+      console.log('checkClipboardPermission', permission);
       setHasPermission(permission);
     } catch (error:any) {
       addError('PERMISSION_CHECK_FAILED', error?.message);

--- a/packages/hooks/src/useClipboard/demo/demo3.tsx
+++ b/packages/hooks/src/useClipboard/demo/demo3.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Card, Divider, List, Space, Switch, Tag, Typography } from 'antd';
+import { ClockCircleOutlined, CopyOutlined, PauseCircleOutlined } from '@ant-design/icons';
+import useClipboard from '../index';
+
+const { Text } = Typography;
+
+interface ClipboardHistory {
+  id: number;
+  content: any;
+  displayText: string;
+  timestamp: Date;
+  type: 'text' | 'object' | 'array';
+  size: number;
+}
+
+const Demo3: React.FC = () => {
+  const [isMonitoring, setIsMonitoring] = useState(false);
+  const [history, setHistory] = useState<ClipboardHistory[]>([]);
+  const [currentContent, setCurrentContent] = useState<string>('');
+  const intervalRef = useRef<any>(null);
+  const lastContentRef = useRef<string>('');
+  const { paste, copy, isSupported } = useClipboard();
+
+  const startMonitoring = () => {
+    intervalRef.current = setInterval(async () => {
+      try {
+        const content = await paste();
+        if (content !== null) {
+          const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
+
+          // 只有内容发生变化时才记录
+          if (contentStr !== lastContentRef.current) {
+            lastContentRef.current = contentStr;
+            setCurrentContent(contentStr);
+
+            const historyItem: ClipboardHistory = {
+              id: Date.now(),
+              content,
+              displayText: typeof content === 'string' ? content : '结构化数据',
+              timestamp: new Date(),
+              type: Array.isArray(content)
+                ? 'array'
+                : typeof content === 'object'
+                  ? 'object'
+                  : 'text',
+              size: contentStr.length,
+            };
+
+            setHistory((prev) => [historyItem, ...prev.slice(0, 9)]); // 保留最近10条记录
+          }
+        }
+      } catch (error) {
+        console.error('监听剪贴板失败:', error);
+      }
+    }, 1000); // 每秒检查一次
+  };
+
+  const stopMonitoring = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = undefined;
+    }
+  };
+  useEffect(() => {
+    if (isMonitoring) {
+      startMonitoring();
+    } else {
+      stopMonitoring();
+    }
+
+    return () => stopMonitoring();
+  }, [isMonitoring]);
+  const handleToggleMonitoring = (checked: boolean) => {
+    setIsMonitoring(checked);
+  };
+
+  const handleCopyFromHistory = async (item: ClipboardHistory) => {
+    try {
+      await copy(item.displayText, item.content);
+    } catch (error) {
+      console.error('复制失败:', error);
+    }
+  };
+
+  const handleClearHistory = () => {
+    setHistory([]);
+    setCurrentContent('');
+    lastContentRef.current = '';
+  };
+
+  const getTypeColor = (type: string) => {
+    switch (type) {
+      case 'text':
+        return 'blue';
+      case 'object':
+        return 'green';
+      case 'array':
+        return 'orange';
+      default:
+        return 'default';
+    }
+  };
+
+  const formatSize = (size: number) => {
+    if (size < 1024) return `${size} B`;
+    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const truncateText = (text: string, maxLength: number = 100) => {
+    return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+  };
+
+  if (!isSupported) {
+    return <div style={{ padding: '20px', color: '#ff4d4f' }}>当前环境不支持 Clipboard API</div>;
+  }
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <Space direction='vertical' size='large' style={{ width: '100%' }}>
+        {/* 控制面板 */}
+        <Card size='small' title='Audio monitoring'>
+          <Space>
+            <Switch
+              checked={isMonitoring}
+              onChange={handleToggleMonitoring}
+              checkedChildren={<ClockCircleOutlined />}
+              unCheckedChildren={<PauseCircleOutlined />}
+            />
+            <Text>{isMonitoring ? 'Listening in...' : 'suspend'}</Text>
+            <Divider type='vertical' />
+            <Button size='small' onClick={handleClearHistory}>
+              Clear
+            </Button>
+            <Text type='secondary'>History: {history.length}/10</Text>
+          </Space>
+        </Card>
+
+        {/* 当前内容 */}
+        {currentContent && (
+          <Card size='small' title='Current clipboard contents'>
+            <Text code style={{ wordBreak: 'break-all' }}>
+              {truncateText(currentContent, 200)}
+            </Text>
+          </Card>
+        )}
+
+        {/* 历史记录 */}
+        <Card
+          size='small'
+          title='Clipboard history'
+          extra={<Text type='secondary'>{isMonitoring ? 'Listening in...' : 'suspend'}</Text>}
+        >
+          {history.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: '40px 0', color: '#999' }}>
+              {isMonitoring ? 'Wait for the clipboard to change...' : 'No historical record'}
+            </div>
+          ) : (
+            <List
+              dataSource={history}
+              renderItem={(item, index) => (
+                <List.Item
+                  actions={[
+                    <Button
+                      key={index}
+                      size='small'
+                      icon={<CopyOutlined />}
+                      onClick={() => handleCopyFromHistory(item)}
+                    >
+                      Copy
+                    </Button>,
+                  ]}
+                >
+                  <List.Item.Meta
+                    title={
+                      <Space>
+                        <Tag color={getTypeColor(item.type)}>{item.type}</Tag>
+                        <Text type='secondary' style={{ fontSize: '12px' }}>
+                          {item.timestamp.toLocaleTimeString()}
+                        </Text>
+                        <Text type='secondary' style={{ fontSize: '12px' }}>
+                          {formatSize(item.size)}
+                        </Text>
+                      </Space>
+                    }
+                    description={
+                      <Text style={{ wordBreak: 'break-all', fontSize: '12px' }}>
+                        {truncateText(
+                          typeof item.content === 'string'
+                            ? item.content
+                            : JSON.stringify(item.content),
+                          150,
+                        )}
+                      </Text>
+                    }
+                  />
+                </List.Item>
+              )}
+            />
+          )}
+        </Card>
+
+        {/* 测试数据 */}
+        <Card size='small' title='Generating test data'>
+          <Space wrap>
+            <Button size='small' onClick={() => copy('ahooks', 'ahooks are unmatched')}>
+              Copy Text
+            </Button>
+            <Button
+              size='small'
+              onClick={() =>
+                copy('UserInfo', {
+                  id: Math.floor(Math.random() * 1000),
+                  name: 'TestUser',
+                  timestamp: new Date().toISOString(),
+                })
+              }
+            >
+              Copy Object
+            </Button>
+            <Button
+              size='small'
+              onClick={() =>
+                copy('Array', [
+                  Math.floor(Math.random() * 100),
+                  Math.floor(Math.random() * 100),
+                  Math.floor(Math.random() * 100),
+                ])
+              }
+            >
+              Copy Array
+            </Button>
+          </Space>
+        </Card>
+
+        {/* 说明信息 */}
+      </Space>
+    </div>
+  );
+};
+
+export default Demo3;

--- a/packages/hooks/src/useClipboard/index.en-US.md
+++ b/packages/hooks/src/useClipboard/index.en-US.md
@@ -1,0 +1,130 @@
+---
+nav:
+  path: /hooks
+---
+
+# useClipboard
+
+A Hook for managing clipboard operations. It supports copying and pasting any type of data to the system clipboard, allows displaying custom text when pasting outside the project, and provides comprehensive error handling and permission checks.
+
+## Demos
+
+
+### Default usage
+
+<code src="./demo/demo1.tsx" />
+
+### Permission Check and Error Handling
+
+<code src="./demo/demo2.tsx" />
+
+
+### Real-time clipboard monitoring
+
+<code src="./demo/demo3.tsx" />
+
+## API
+
+```
+const { copy, paste, isSupported, hasPermission } = useClipboard();
+```
+
+### Result
+
+|Parameter|Description|Type|
+|---|---|---|
+|copy|Copies data to the clipboard.|`<T>(displayText: string, data: T) => Promise<void>`|
+|paste|Pastes data from the clipboard.|`<T>() => Promise<T \| string \| null>`|
+|isSupported|Whether the current environment supports the Clipboard API.|`boolean`|
+|hasPermission|Checks for clipboard permissions.|`() => Promise<boolean>`|
+
+### copy
+
+Copies data to the clipboard, supporting any serializable data structure.
+
+**Parameters:**
+
+|Parameter|Description|Type|Required|
+|---|---|---|---|
+|displayText|The plain text to be displayed in the clipboard.|`string`|Yes|
+|data|The data to be copied, can be any serializable object.|`T`|Yes|
+
+**Example:**
+
+```
+// Copy text
+await copy('Hello World', 'Hello World');
+
+// Copy an object
+await copy('User Info', { id: 1, name: 'John', age: 25 });
+
+// Copy an array
+await copy('Shopping List', ['Apple', 'Banana', 'Orange']);
+```
+
+### paste
+
+Reads data from the clipboard and automatically identifies the data type.
+
+**Return Value:**
+
+- If it's structured data copied via `copy`, it returns the original data.
+
+- If it's plain text, it returns a string.
+
+- If the clipboard is empty or the read fails, it returns `null`.
+
+
+**Example:**
+
+```
+const data = await paste();
+
+if (typeof data === 'string') {
+  console.log('Pasted text:', data);
+} else if (data && typeof data === 'object') {
+  console.log('Pasted structured data:', data);
+} else {
+  console.log('Clipboard is empty or read failed.');
+}
+```
+
+### Error Handling
+
+The hook throws errors of type `ClipboardError`, which include a detailed error message and an error code.
+
+**Error Codes:**
+
+|Error Code|Description|
+|---|---|
+|UNSUPPORTED|Clipboard API is not supported in the current environment.|
+|INVALID_INPUT|Invalid input parameters.|
+|DATA_TOO_LARGE|Data exceeds the size limit (1MB).|
+|PERMISSION_DENIED|User denied clipboard permission.|
+|SECURITY_ERROR|Security policy prevents clipboard access.|
+|COPY_FAILED|The copy operation failed.|
+|PASTE_FAILED|The paste operation failed.|
+
+**Example:**
+
+```
+try {
+  await copy('Data', someData);
+} catch (error) {
+  if (error instanceof ClipboardError) {
+    console.error(`Clipboard Error [${error.code}]:`, error.message);
+  }
+}
+```
+
+## Notes
+
+1. **Environment**: Must be used in an HTTPS environment or on `localhost`.
+
+2. **Permissions**: The browser will request clipboard permissions on the first use.
+
+3. **Data Size**: It is recommended that the data for a single copy operation not exceed 1MB.
+
+4. **Compatibility**: Requires a modern browser that supports the Clipboard API.
+
+5. **Security**: Sensitive data will exist temporarily in the clipboard; be mindful of security when using.

--- a/packages/hooks/src/useClipboard/index.ts
+++ b/packages/hooks/src/useClipboard/index.ts
@@ -243,20 +243,29 @@ function useClipboard(): UseClipboard {
         throw error;
       }
 
-      let errorCode = 'PASTE_FAILED';
-      let errorMessage = 'Failed to read from clipboard';
+const errorMap = {
+ ['NotAllowedError']: {
+    code: 'PERMISSION_DENIED',
+    message: 'Clipboard read access denied. Please grant permission.'
+  },
+  ['SECURITY_ERROR']: {
+    code: 'SECURITY_ERROR',
+    message: 'Clipboard access blocked by security policy'
+  }
+};
 
-      if (error instanceof Error) {
-        if (error.name === 'NotAllowedError') {
-          errorCode = 'PERMISSION_DENIED';
-          errorMessage = 'Clipboard read access denied. Please grant permission.';
-        } else if (error.name === 'SecurityError') {
-          errorCode = 'SECURITY_ERROR';
-          errorMessage = 'Clipboard access blocked by security policy';
-        } else {
-          errorMessage = `${errorMessage}: ${error.message}`;
-        }
-      }
+let errorCode = 'COPY_FAILED';
+let errorMessage = 'Failed to copy to clipboard';
+
+if (error instanceof Error) {
+  const mapped = errorMap[error.name];
+  if (mapped) {
+    errorCode = mapped.code;
+    errorMessage = mapped.message;
+  } else {
+    errorMessage = `${errorMessage}: ${error.message}`;
+  }
+}
 
       throw new ClipboardError(errorMessage, errorCode);
     }

--- a/packages/hooks/src/useClipboard/index.ts
+++ b/packages/hooks/src/useClipboard/index.ts
@@ -1,0 +1,273 @@
+import {useCallback, useMemo} from 'react';
+
+type FlexibleClipboardData<T = any> = T;
+
+// 定义返回的 useClipboard 钩子的类型
+interface UseClipboard {
+  copy: <T = any>(displayText: string, data: FlexibleClipboardData<T>) => Promise<void>;
+  paste: <T = any>() => Promise<FlexibleClipboardData<T> | string | null>;
+  isSupported: boolean;
+  hasPermission: () => Promise<boolean>;
+}
+
+// 自定义错误类型
+class ClipboardError extends Error {
+  public readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'ClipboardError';
+    this.code = code;
+  }
+}
+// 常量定义
+const CLIPBOARD_DATA_MARKER = '__clipboardData';
+const CLIPBOARD_VERSION = '1.0';
+function useClipboard(): UseClipboard {
+  // 检查剪贴板API是否可用 - 使用 useMemo 避免重复计算
+  const isSupported = useMemo(() => {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return false;
+    }
+
+    return (
+      'clipboard' in navigator &&
+      'write' in navigator.clipboard &&
+      'read' in navigator.clipboard &&
+      window.isSecureContext // HTTPS 或 localhost 环境
+    );
+  }, []);
+
+  // 检查剪贴板权限
+  const hasPermission = useCallback(async (): Promise<boolean> => {
+    if (!isSupported) return false;
+
+    try {
+      // 检查读写权限
+      const writePermission = await navigator.permissions.query({
+        name: 'clipboard-write' as PermissionName,
+      });
+      const readPermission = await navigator.permissions.query({
+        name: 'clipboard-read' as PermissionName,
+      });
+      return writePermission.state !== 'denied' && readPermission.state !== 'denied';
+    } catch {
+      // 如果权限API不可用，尝试实际操作来测试
+      try {
+        await navigator.clipboard.readText();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }, [isSupported]);
+
+  const validateInput = useCallback(
+    <T = any>(displayText: string, data: FlexibleClipboardData<T>): void => {
+      if (!displayText.trim()) {
+        throw new ClipboardError('Display text must be a non-empty string', 'INVALID_INPUT');
+      }
+
+      if (data === null || data === undefined) {
+        throw new ClipboardError('Data cannot be null or undefined', 'INVALID_INPUT');
+      }
+      // 检查数据大小（Chrome 限制约 2MB）
+      const dataSize = JSON.stringify(data).length;
+      if (dataSize > 1024 * 1024) {
+        // 1MB 限制
+        throw new ClipboardError('Data size exceeds limit (1MB)', 'DATA_TOO_LARGE');
+      }
+    },
+    [],
+  );
+
+  // 创建包装数据
+  const createWrappedData = useCallback(
+    <T = any>(data: FlexibleClipboardData<T>) => ({
+      [CLIPBOARD_DATA_MARKER]: true,
+      version: CLIPBOARD_VERSION,
+      timestamp: Date.now(),
+      data: data, // 将实际数据包装在 data 字段中
+    }),
+    [],
+  );
+
+  // 验证和解包数据
+  const unwrapData = useCallback(<T = any>(rawData: any): FlexibleClipboardData<T> | null => {
+    if (!rawData || typeof rawData !== 'object') {
+      return null;
+    }
+
+    if (!rawData[CLIPBOARD_DATA_MARKER]) {
+      return null;
+    }
+
+    // 版本兼容性检查
+    if (rawData.version && rawData.version !== CLIPBOARD_VERSION) {
+      console.warn(`Clipboard data version mismatch: ${rawData.version} vs ${CLIPBOARD_VERSION}`);
+    }
+    // 返回包装的实际数据
+    return rawData.data as FlexibleClipboardData<T>;
+  }, []);
+
+  // 复制到剪贴板
+  const copy = useCallback(
+    async <T = any>(displayText: string, data: FlexibleClipboardData<T>): Promise<void> => {
+      if (!isSupported) {
+        throw new ClipboardError(
+          'Clipboard API is not supported in this environment',
+          'UNSUPPORTED',
+        );
+      }
+
+      validateInput(displayText, data);
+
+      try {
+        const wrappedData = createWrappedData(data);
+        const jsonString = JSON.stringify(wrappedData);
+
+        // 创建剪贴板项
+        const clipboardItems: Record<string, Blob> = {
+          'text/plain': new Blob([displayText], { type: 'text/plain' }),
+        };
+
+        // 只有在支持的情况下才添加 HTML 格式
+        if (ClipboardItem.supports && ClipboardItem.supports('text/html')) {
+          clipboardItems['text/html'] = new Blob([jsonString], { type: 'text/html' });
+        } else {
+          // 降级方案：将数据编码到纯文本中
+          const encodedData = `${displayText}\n__CLIPBOARD_DATA__:${btoa(jsonString)}`;
+          clipboardItems['text/plain'] = new Blob([encodedData], { type: 'text/plain' });
+        }
+
+        const clipboardItem = new ClipboardItem(clipboardItems);
+        await navigator.clipboard.write([clipboardItem]);
+      } catch (error) {
+        if (error instanceof ClipboardError) {
+          throw error;
+        }
+
+        // 详细的错误处理
+        let errorCode = 'COPY_FAILED';
+        let errorMessage = 'Failed to copy to clipboard';
+        if (error instanceof Error) {
+          if (error.name === 'NotAllowedError') {
+            errorCode = 'PERMISSION_DENIED';
+            errorMessage = 'Clipboard access denied. Please grant permission.';
+          } else if (error.name === 'DataError') {
+            errorCode = 'INVALID_FORMAT';
+            errorMessage = 'Invalid data format for clipboard';
+          } else if (error.name === 'SecurityError') {
+            errorCode = 'SECURITY_ERROR';
+            errorMessage = 'Clipboard access blocked by security policy';
+          } else {
+            errorMessage = `${errorMessage}: ${error.message}`;
+          }
+        }
+
+        throw new ClipboardError(errorMessage, errorCode);
+      }
+    },
+    [isSupported, validateInput, createWrappedData],
+  );
+
+  // 从剪贴板粘贴
+  const paste = useCallback(async <T = any>(): Promise<
+    FlexibleClipboardData<T> | string | null
+  > => {
+    if (!isSupported) {
+      throw new ClipboardError('Clipboard API is not supported in this environment', 'UNSUPPORTED');
+    }
+
+    try {
+      const clipboardItems = await navigator.clipboard.read();
+
+      if (!clipboardItems?.length) {
+        return null;
+      }
+
+      for (const item of clipboardItems) {
+        // 优先尝试读取 HTML 格式的结构化数据
+        if (item.types.includes('text/html')) {
+          try {
+            const htmlBlob = await item.getType('text/html');
+            const jsonText = await htmlBlob.text();
+
+            if (jsonText) {
+              const parsedData = JSON.parse(jsonText);
+              const unwrapped = unwrapData<T>(parsedData);
+              if (unwrapped !== null) {
+                return unwrapped;
+              }
+            }
+          } catch (parseError) {
+            console.debug('Failed to parse HTML clipboard data:', parseError);
+          }
+        }
+
+        // 尝试读取纯文本（可能包含编码的数据）
+        if (item.types.includes('text/plain')) {
+          const plainBlob = await item.getType('text/plain');
+          const plainText = await plainBlob.text();
+
+          if (!plainText) {
+            continue;
+          }
+
+          // 检查是否是编码的数据（降级方案）
+          const dataMarker = '\n__CLIPBOARD_DATA__:';
+          const markerIndex = plainText.indexOf(dataMarker);
+
+          if (markerIndex !== -1) {
+            try {
+              const encodedData = plainText.substring(markerIndex + dataMarker.length);
+              const decodedData = JSON.parse(atob(encodedData));
+              const unwrapped = unwrapData<T>(decodedData);
+
+              if (unwrapped !== null) {
+                return unwrapped;
+              }
+            } catch (decodeError) {
+              console.debug('Failed to decode embedded clipboard data:', decodeError);
+            }
+          }
+
+          // 返回纯文本
+          return plainText;
+        }
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof ClipboardError) {
+        throw error;
+      }
+
+      let errorCode = 'PASTE_FAILED';
+      let errorMessage = 'Failed to read from clipboard';
+
+      if (error instanceof Error) {
+        if (error.name === 'NotAllowedError') {
+          errorCode = 'PERMISSION_DENIED';
+          errorMessage = 'Clipboard read access denied. Please grant permission.';
+        } else if (error.name === 'SecurityError') {
+          errorCode = 'SECURITY_ERROR';
+          errorMessage = 'Clipboard access blocked by security policy';
+        } else {
+          errorMessage = `${errorMessage}: ${error.message}`;
+        }
+      }
+
+      throw new ClipboardError(errorMessage, errorCode);
+    }
+  }, [isSupported, unwrapData]);
+
+  return {
+    copy,
+    paste,
+    isSupported,
+    hasPermission,
+  };
+}
+
+export default useClipboard;

--- a/packages/hooks/src/useClipboard/index.zh-CN.md
+++ b/packages/hooks/src/useClipboard/index.zh-CN.md
@@ -1,0 +1,126 @@
+---
+nav:
+  path: /hooks
+---
+
+# useClipboard
+
+用于管理剪贴板操作的 Hook，支持复制和粘贴任意类型的数据到系统剪贴板，支持粘贴到项目外时显示自定义文本，并提供完整的错误处理和权限检查。
+
+## 代码演示
+
+
+
+### 基础用法
+
+<code src="./demo/demo1.tsx" />
+
+### 权限检查和错误处理
+
+<code src="./demo/demo2.tsx" />
+
+
+### 实时监听
+
+<code src="./demo/demo3.tsx" />
+
+## API
+
+```typescript
+const { copy, paste, isSupported, hasPermission } = useClipboard();
+```
+
+### Result
+
+| 参数                | 说明                           | 类型                                                                                    |
+| ------------------- | ------------------------------ | --------------------------------------------------------------------------------------- |
+| copy     | 复制数据到剪贴板               | `<T>(displayText: string, data: T) => Promise<void>`                                   |
+| paste  | 从剪贴板粘贴数据               | `<T>() => Promise<T \| string \| null>`                                                |
+| isSupported         | 当前环境是否支持 Clipboard API | `boolean`                                                                               |
+| hasPermission       | 检查是否有剪贴板权限           | `() => Promise<boolean>`                                                                |
+
+### copy
+
+复制数据到剪贴板，支持任意类型的数据结构。
+
+**参数:**
+
+| 参数        | 说明                                     | 类型     | 必填 |
+| ----------- | ---------------------------------------- | -------- | ---- |
+| displayText | 在剪贴板中显示的纯文本                   | `string` | 是   |
+| data        | 要复制的数据，可以是任意可序列化的对象   | `T`      | 是   |
+
+**示例:**
+
+```typescript
+// 复制文本
+await copy('Hello World', 'Hello World');
+
+// 复制对象
+await copy('用户信息', { id: 1, name: 'John', age: 25 });
+
+// 复制数组
+await copy('购物清单', ['苹果', '香蕉', '橙子']);
+```
+
+### paste
+
+从剪贴板读取数据，会自动识别数据类型。
+
+**返回值:**
+
+- 如果是通过 `copy` 复制的结构化数据，返回原始数据
+- 如果是普通文本，返回字符串
+- 如果剪贴板为空或读取失败，返回 `null`
+
+**示例:**
+
+```typescript
+const data = await paste();
+
+if (typeof data === 'string') {
+  console.log('粘贴的文本:', data);
+} else if (data && typeof data === 'object') {
+  console.log('粘贴的结构化数据:', data);
+} else {
+  console.log('剪贴板为空或读取失败');
+}
+```
+
+### 错误处理
+
+Hook 会抛出 `ClipboardError` 类型的错误，包含详细的错误信息和错误代码。
+
+**错误代码:**
+
+| 错误代码          | 说明                     |
+| ----------------- | ------------------------ |
+| UNSUPPORTED       | 当前环境不支持剪贴板 API |
+| INVALID_INPUT     | 输入参数无效             |
+| DATA_TOO_LARGE    | 数据超过大小限制 (1MB)   |
+| PERMISSION_DENIED | 用户拒绝剪贴板权限       |
+| SECURITY_ERROR    | 安全策略阻止剪贴板访问   |
+| COPY_FAILED       | 复制操作失败             |
+| PASTE_FAILED      | 粘贴操作失败             |
+
+**示例:**
+
+```typescript
+try {
+  await copy('数据', someData);
+} catch (error) {
+  if (error instanceof ClipboardError) {
+    console.error(`剪贴板错误 [${error.code}]:`, error.message);
+  }
+}
+```
+
+## 注意事项
+
+1. **环境要求**: 需要在 HTTPS 环境或 localhost 下使用
+2. **权限**: 首次使用时浏览器会请求剪贴板权限
+3. **数据大小**: 建议单次复制的数据不超过 1MB
+4. **兼容性**: 需要现代浏览器支持 Clipboard API
+5. **安全性**: 敏感数据会在剪贴板中短暂存在，使用时需注意安全
+
+


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交（新增 `useClipboard`）
- [x] 测试用例
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

---

### 💡 需求背景和解决方案

**需求背景**
- 需要在 Web 环境中实现**结构化数据**的复制与粘贴：对用户展示可读的可见文本（`displayText`），同时在剪贴板中携带真实 JSON 数据。

**解决方案：新增 Hook `useClipboard`**

```ts
type FlexibleClipboardData<T = any> = T;

interface UseClipboard {
  copy: <T = any>(displayText: string, data: FlexibleClipboardData<T>) => Promise<void>;
  paste: <T = any>() => Promise<FlexibleClipboardData<T> | string | null>;
  isSupported: boolean;
  hasPermission: () => Promise<boolean>;
}
```
现代浏览器（优先）：用 ClipboardItem 同时写两种 MIME：

text/plain → displayText（用户粘贴到输入框只会看到这段文字）

text/html → JSON（程序读取用，普通粘贴一般看不见）

降级方案（不支持 text/html 时）：只写 text/plain，把 JSON Base64 编码后贴在末尾并打上标记：

${displayText}\n__CLIPBOARD_DATA__:${btoa(json)}


### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add useClipboard to copy/paste structured payloads with graceful fallback. Expose isSupported and hasPermission. Provide comprehensive Vitest tests. No breaking changes.          |
| 🇨🇳 中文 |     新增 `useClipboard`，支持结构化复制/粘贴并在不支持场景优雅降级；提供 `isSupported` 与 `hasPermission`；补充完整 Vitest 测试。无破坏性变更。     |



☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充

- [x]  代码演示已提供或无须提供

 - [x] TypeScript 定义已补充或无须补充

 - [x] Changelog 已提供或无须提供