### PR TITLE
feat: useCountdown 新增 currentServerTime 配置

### DIFF
--- a/packages/hooks/src/useCountDown/demo/demo4.tsx
+++ b/packages/hooks/src/useCountDown/demo/demo4.tsx
@@ -1,0 +1,20 @@
+/**
+ * title: Configure the server time
+ * desc: Because users may change their local system time, the countdown can become inaccurate when using targetDate.
+ *
+ * title.zh-CN: 配置服务器时间
+ * desc.zh-CN: 防止用户修改本地时间，导致配置 targetDate 时倒计时不准确，通过 currentServerTime 配置当前服务器时间
+ */
+
+import React, { useMemo } from "react";
+import { useCountDown } from "ahooks";
+
+const App: React.FC = () => {
+  // should be get from server
+  const currentServerTime = useMemo(() => Date.now(), []);
+
+  const [countdown] = useCountDown({ leftTime: 60 * 1000, currentServerTime });
+  return <p>{countdown}</p>;
+};
+
+export default App;

--- a/packages/hooks/src/useCountDown/index.en-US.md
+++ b/packages/hooks/src/useCountDown/index.en-US.md
@@ -19,6 +19,10 @@ A hook for manage countdown.
 
 <code src="./demo/demo3.tsx" />
 
+## Config currentServerTime
+
+<code src="./demo/demo4.tsx" />
+
 ## API
 
 ```typescript
@@ -37,6 +41,7 @@ const [countdown, formattedRes] = useCountDown(
     leftTime,
     targetDate,
     interval,
+    currentServerTime,
     onEnd
   }
 );
@@ -53,6 +58,8 @@ If you only need to be accurate to the second, you can use it like this `Math.ro
 
 If both `leftTime` and `targetDate` are passed, the `targetDate` is ignored, the `leftTime` is dominant.
 
+If 'currentServerTime' is not configured, the local time is used for the countdown.
+
 ### Params
 
 | Property   | Description                                  | Type         | Default |
@@ -60,6 +67,7 @@ If both `leftTime` and `targetDate` are passed, the `targetDate` is ignored, the
 | leftTime   | The rest of time, in milliseconds            | `number`     | -       |
 | targetDate | Target time                                  | `TDate`      | -       |
 | interval   | Time interval between ticks, in milliseconds | `number`     | `1000`  |
+| currentServerTime   | Current server time, in milliseconds | `number`     | -  |
 | onEnd      | Function to call when countdown completes    | `() => void` | -       |
 
 ### Return
@@ -71,4 +79,4 @@ If both `leftTime` and `targetDate` are passed, the `targetDate` is ignored, the
 
 ## Remark
 
-`leftTime`、`targetDate`、`interval`、`onEnd` support dynamic change.
+`leftTime`、`targetDate`、`interval`、`currentServerTime`、`onEnd` support dynamic change.

--- a/packages/hooks/src/useCountDown/index.zh-CN.md
+++ b/packages/hooks/src/useCountDown/index.zh-CN.md
@@ -19,6 +19,10 @@ nav:
 
 <code src="./demo/demo3.tsx" />
 
+## 通过 currentServerTime 配置当前服务器时间
+
+<code src="./demo/demo4.tsx" />
+
 **说明**
 
 useCountDown 的精度为毫秒，可能会造成以下几个问题
@@ -28,7 +32,9 @@ useCountDown 的精度为毫秒，可能会造成以下几个问题
 
 如果你的精度只要到秒就好了，可以这样用 `Math.round(countdown / 1000)`。
 
-如果同时传了 `leftTime` 和 `targetDate`，则会忽略 `targetDate`，以 `leftTime` 为主
+如果同时传了 `leftTime` 和 `targetDate`，则会忽略 `targetDate`，以 `leftTime` 为主。
+
+如果没有配置 `currentServerTime` ，则会使用本地时间进行倒计时 。
 
 ## API
 
@@ -48,6 +54,7 @@ const [countdown, formattedRes] = useCountDown(
     leftTime,
     targetDate,
     interval,
+    currentServerTime,
     onEnd
   }
 );
@@ -60,6 +67,7 @@ const [countdown, formattedRes] = useCountDown(
 | leftTime   | 剩余时间（毫秒）     | `number`     | -      |
 | targetDate | 目标时间             | `TDate`      | -      |
 | interval   | 变化时间间隔（毫秒） | `number`     | `1000` |
+| currentServerTime   | 当前服务器时间（毫秒） | `number`     | - |
 | onEnd      | 倒计时结束触发       | `() => void` | -      |
 
 ### Result
@@ -71,4 +79,4 @@ const [countdown, formattedRes] = useCountDown(
 
 ## 备注
 
-`leftTime`、`targetDate`、`interval`、`onEnd` 支持动态变化
+`leftTime`、`targetDate`、`interval`、`currentServerTime`、`onEnd` 支持动态变化


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案
- 因为用户可能修改本地系统时间，直接用 targetDate（基于 Date.now()）计算会导致倒计时不准确。
- 目标：倒计时应与“权威时间源”（服务端）对齐，具备抗本地时间篡改能力，并可控误差。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
- useCountdown 新增了 currentServerTime 配置，当未配置此字段时，会使用本地时间进行倒计时，与之前版本一样，用户升级后不会影响已有逻辑，保持向前兼容原则。

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |      Added `currentServerTime` configuration instructions and example code    |
| 🇨🇳 中文 |     新增了`currentServerTime`的配置说明和实例代码     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供