### PR TITLE
fix(useRequest): return immediately in runAsync when ready=false (no pending)

### DIFF
--- a/packages/hooks/src/useRequest/__tests__/index.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/index.spec.ts
@@ -193,6 +193,61 @@ describe('useRequest', () => {
     hook.unmount();
   });
 
+  test('runAsync should resolve immediately when ready=false', async () => {
+    // manual = true
+    act(() => {
+      hook = setUp(request, {
+        manual: true,
+        ready: false,
+      });
+    });
+    expect(hook.result.current.loading).toBe(false);
+
+    let resolved = false;
+    let value: any = 'init';
+
+    await act(async () => {
+      hook.result.current
+        .runAsync(1)
+        .then((res: any) => {
+          resolved = true;
+          value = res;
+        });
+      await Promise.resolve();
+    });
+
+    expect(resolved).toBe(true);
+    expect(value).toBeUndefined();
+    expect(hook.result.current.loading).toBe(false);
+    hook.unmount();
+
+    // manual = false
+    act(() => {
+      hook = setUp(request, {
+        ready: false,
+      });
+    });
+    expect(hook.result.current.loading).toBe(false);
+
+    resolved = false;
+    value = 'init';
+
+    await act(async () => {
+      hook.result.current
+        .runAsync(1)
+        .then((res: any) => {
+          resolved = true;
+          value = res;
+        });
+      await Promise.resolve();
+    });
+
+    expect(resolved).toBe(true);
+    expect(value).toBeUndefined();
+    expect(hook.result.current.loading).toBe(false);
+    hook.unmount();
+  });
+
   test('useRequest defaultParams should work', async () => {
     act(() => {
       hook = setUp<string, [number, number, number]>(request, {

--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -54,7 +54,7 @@ export default class Fetch<TData, TParams extends any[]> {
 
     // stop request
     if (stopNow) {
-      return new Promise(() => {});
+      return Promise.resolve(state.data);
     }
 
     this.setState({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

Close #2792

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

- Background:
  - In `useRequest`, when `ready=false`, calling `runAsync` returns a Promise that stays pending, causing the call to hang.
- Solution:
  - In `Fetch.runAsync`, when a plugin signals `stopNow`, return `Promise.resolve(state.data)` instead of a never-resolving Promise.
  - Add tests to ensure that when `ready=false` (in both manual and auto modes), `runAsync` resolves immediately and does not remain pending.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

```js
function Component() {
  const { runAsync } = useRequest(fetchUser, { manual: true, ready: false });

  const onSave = async () => {
    const res = await runAsync({ id: 1 });
    // Before: this code never ran because the await above blocked indefinitely
    // After: written like this, it throws:
    // Uncaught TypeError: Cannot read properties of undefined (reading 'user')
    alert(res.user);
  };

  return <button onClick={onSave}>Save</button>;
}
```

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix(useRequest): return immediately in runAsync when ready=false (no pending)      |
| 🇨🇳 Chinese |      fix(useRequest): 当 ready=false 时调用 runAsync 立即返回而不是阻塞     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
