### PR TITLE
fix(useInfiniteScroll): fix duplicate trigger requests

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -37,7 +37,7 @@ const useInfiniteScroll = <TData extends Data>(
       return false;
     }
     return isNoMore(finalData);
-  }, [finalData]);
+  }, [finalData, isNoMore]);
 
   const { loading, error, run, runAsync, cancel } = useRequest(
     async (lastData?: TData) => {
@@ -87,7 +87,7 @@ const useInfiniteScroll = <TData extends Data>(
   );
 
   const loadMore = useMemoizedFn(() => {
-    if (noMore) {
+    if (noMore || loading) {
       return;
     }
     setLoadingMore(true);
@@ -100,7 +100,7 @@ const useInfiniteScroll = <TData extends Data>(
   };
 
   const loadMoreAsync = useMemoizedFn(() => {
-    if (noMore) {
+    if (noMore || loading) {
       return Promise.reject();
     }
     setLoadingMore(true);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2878 

### 💡 Background and solution
####  Background:
- LoadMore was triggered before the initial request ended.
####  Solution:
- Add status checks before calling loadMore.

### 📝 Changelog
```js
  const loadMore = useMemoizedFn(() => {
    // If loading is true do nothing
    if (noMore || loading) {
      return;
    }
    setLoadingMore(true);
    run(finalData);
  });

  const loadMoreAsync = useMemoizedFn(() => {
    if (noMore || loading) {
      return Promise.reject();
    }
    setLoadingMore(true);
    return runAsyncForCurrent(finalData);
  });
```

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix(useInfiniteScroll): fix duplicate trigger requests      |
| 🇨🇳 Chinese |    fix(useInfiniteScroll): 修复重复的触发请求       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
