### PR TITLE
refactor: replace useCallback with useMemoizedFn in useUpdate

### DIFF
--- a/packages/hooks/src/useUpdate/index.ts
+++ b/packages/hooks/src/useUpdate/index.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useState } from "react";
+import useMemoizedFn from "../useMemoizedFn";
 
 const useUpdate = () => {
   const [, setState] = useState({});
 
-  return useCallback(() => setState({}), []);
+  return useMemoizedFn(() => setState({}));
 };
 
 export default useUpdate;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

使用 `useMemoizedFn` 包装 `useUpdate` 返回的函数，确保函数引用在组件重新渲染时保持稳定，避免不必要的副作用触发。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize `useUpdate` to return a stable function reference using `useMemoizedFn`. |
| 🇨🇳 Chinese | 优化 `useUpdate`，使用 `useMemoizedFn` 返回稳定的函数引用。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed