### PR TITLE
Fix: Add alt attributes to discussion group images for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Thanks to all the contributors:
 
 ## 👥 Discuss
 
-<img src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
+<img alt="ahooks discussion group 1" src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
+<img alt="ahooks discussion group 2" src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
+<img alt="ahooks discussion group 3" src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
 
 [1]: https://www.npmjs.com/package/ahooks
 [2]: https://npmjs.org/package/ahooks

--- a/docs/index.en-US.md
+++ b/docs/index.en-US.md
@@ -74,9 +74,9 @@ Thanks to all the contributors:
 
 ## 👥 Discuss
 
-<img src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
+<img alt="ahooks discussion group 1" src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
+<img alt="ahooks discussion group 2" src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
+<img alt="ahooks discussion group 3" src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
 
 [1]: https://www.npmjs.com/package/ahooks
 [2]: https://npmjs.org/package/ahooks

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -73,9 +73,9 @@ $ pnpm start
 
 ## 👥 交流讨论
 
-<img src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
-<img src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
+<img alt="ahooks 交流群1" src="https://github.com/user-attachments/assets/0ba7a370-2a69-442f-b746-9eb16bbbc46c" width="200" style='display:inline' />
+<img alt="ahooks 交流群2" src="https://github.com/user-attachments/assets/a08693d3-bfcc-4aca-b2b0-2d9c23012858" width="200" style='display:inline' />
+<img alt="ahooks 交流群3" src="https://github.com/user-attachments/assets/15a505a7-06d1-4e72-ab02-6fad968323f1" width="200" style='display:inline' />
 
 [1]: https://www.npmjs.com/package/ahooks
 [2]: https://npmjs.org/package/ahooks


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

N/A - Accessibility improvement identified through IBM Equal Access Accessibility Checker

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.8) on the [homepage](https://ahooks.js.org/), 3 violations were identified in the documentation. The discussion group QR code images in `README.md` and documentation files were missing `alt` attributes, making them inaccessible to screen reader users.

<img width="2560" height="918" alt="image" src="https://github.com/user-attachments/assets/a45309f2-65f9-4298-b67f-ec23bea3a0e1" />

**Why is this important?**

When an image contains important information, providing a text alternative makes the same information accessible through assistive technologies, such as a Braille display. When an image is decorative or redundant, providing correct markup allows assistive technologies to ignore or not repeat the information.


#### Solution:
Added descriptive alt attributes to all 3 discussion group images:

- English documentation: `alt="ahooks discussion group 1/2/3"`
- Chinese documentation: `alt="ahooks 交流群1/2/3"`

This ensures that users relying on assistive technologies can understand these are QR codes for joining discussion groups.

**Fix Before:**
<img width="317" height="166" alt="image" src="https://github.com/user-attachments/assets/e8c054e9-a6e5-4bd9-b455-1513177ebf71" />

**Fix After:**
<img width="314" height="198" alt="image" src="https://github.com/user-attachments/assets/4587005b-f03d-44fc-8d9c-7149f7999f48" />


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add alt attributes to discussion group QR code images for better accessibility        |
| 🇨🇳 Chinese |    为交流群二维码图片添加 alt 属性以提升可访问性       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
