### PR TITLE
fix(useInfiniteScroll): Closure issue preventing access to the latest data during the initial loadMore() call

### DIFF
--- a/packages/hooks/src/useInfiniteScroll/__tests__/index.spec.ts
+++ b/packages/hooks/src/useInfiniteScroll/__tests__/index.spec.ts
@@ -532,4 +532,84 @@ describe('useInfiniteScroll', () => {
     scrollHeightSpy.mockRestore();
     clientHeightSpy.mockRestore();
   });
+
+  test('should auto loadMore after initial load when container is not full, and second request receives the latest finalData', async () => {
+    setTargetInfo('scrollTop', 0);
+    const scrollHeightSpy = vi.spyOn(targetEl, 'scrollHeight', 'get').mockImplementation(() => 50);
+    const clientHeightSpy = vi.spyOn(targetEl, 'clientHeight', 'get').mockImplementation(() => 300);
+
+    let capturedLastData: any;
+    const service = vi.fn(async (lastData?: any) => {
+      capturedLastData = lastData;
+      await sleep(1000);
+      if (!lastData) {
+        return { list: [1, 2, 3], nextId: 1 };
+      }
+      return { list: [4, 5, 6] };
+    });
+
+    const { result } = setup(service, {
+      target: targetEl,
+      isNoMore: (d) => d?.nextId === undefined,
+    });
+
+    // Wait for initial load to complete
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Container is not full, so scrollMethod should have auto-triggered loadMore
+    expect(result.current.loadingMore).toBe(true);
+    // The second call must receive the up-to-date finalData (not the stale closure value)
+    expect(capturedLastData).toMatchObject({ list: [1, 2, 3], nextId: 1 });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.data?.list).toMatchObject([1, 2, 3, 4, 5, 6]);
+    expect(result.current.noMore).toBe(true);
+
+    scrollHeightSpy.mockRestore();
+    clientHeightSpy.mockRestore();
+  });
+
+  test('mutate should not trigger extra loadMore', async () => {
+    setTargetInfo('scrollTop', 0);
+    const scrollHeightSpy = vi.spyOn(targetEl, 'scrollHeight', 'get').mockImplementation(() => 50);
+    const clientHeightSpy = vi.spyOn(targetEl, 'clientHeight', 'get').mockImplementation(() => 300);
+
+    const service = vi.fn(mockRequest);
+    const { result } = setup(service, {
+      target: targetEl,
+      isNoMore: (d) => d?.nextId === undefined,
+    });
+
+    // Wait for initial load to complete; this auto-triggers a second load
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    // Wait for the auto-triggered second load to complete
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.noMore).toBe(true);
+
+    const callCountAfterLoad = service.mock.calls.length;
+
+    // Mutate with data that makes noMore false, so loadMore *would* fire if scrollMethod ran
+    act(() => {
+      result.current.mutate({ list: [10, 20], nextId: 1 });
+    });
+
+    // Wait for any effects to run
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // mutate should NOT trigger additional requests via scrollMethod
+    expect(service).toBeCalledTimes(callCountAfterLoad);
+
+    scrollHeightSpy.mockRestore();
+    clientHeightSpy.mockRestore();
+  });
 });

--- a/packages/hooks/src/useInfiniteScroll/__tests__/index.spec.ts
+++ b/packages/hooks/src/useInfiniteScroll/__tests__/index.spec.ts
@@ -566,7 +566,7 @@ describe('useInfiniteScroll', () => {
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
-    expect(result.current.data?.list).toMatchObject([1, 2, 3, 4, 5, 6]);
+    expect(result.current.data?.list).toEqual([1, 2, 3, 4, 5, 6]);
     expect(result.current.noMore).toBe(true);
 
     scrollHeightSpy.mockRestore();

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -76,9 +76,6 @@ const useInfiniteScroll = <TData extends Data>(
                 const scrollHeight = getScrollHeight(el);
                 (el as Element).scrollTo(0, scrollHeight - scrollBottom.current);
               }
-            } else {
-              // eslint-disable-next-line @typescript-eslint/no-use-before-define
-              scrollMethod();
             }
           });
         });
@@ -145,6 +142,9 @@ const useInfiniteScroll = <TData extends Data>(
       loadMore();
     }
   };
+  useUpdateEffect(() => {
+    scrollMethod();
+  }, [finalData]);
 
   useEventListener(
     'scroll',

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -31,6 +31,8 @@ const useInfiniteScroll = <TData extends Data>(
   const lastScrollTop = useRef<number>(undefined);
   // scrollBottom is used to record the distance from the bottom of the scroll bar
   const scrollBottom = useRef<number>(0);
+  // flag: set in onSuccess (bottom direction only) to trigger scrollMethod via effect
+  const shouldScrollCheckRef = useRef(false);
 
   const noMore = useMemo(() => {
     if (!isNoMore) {
@@ -80,6 +82,9 @@ const useInfiniteScroll = <TData extends Data>(
           });
         });
 
+        if (!isScrollToTop) {
+          shouldScrollCheckRef.current = true;
+        }
         onSuccess?.(d.currentData);
       },
       onError: (e) => onError?.(e),
@@ -143,6 +148,10 @@ const useInfiniteScroll = <TData extends Data>(
     }
   };
   useUpdateEffect(() => {
+    if (!shouldScrollCheckRef.current) {
+      return;
+    }
+    shouldScrollCheckRef.current = false;
     scrollMethod();
   }, [finalData]);
 

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -68,21 +68,19 @@ const useInfiniteScroll = <TData extends Data>(
           });
         }
 
-        setTimeout(() => {
-          // use requestAnimationFrame to ensure the scroll position is updated (To ensure compatibility react 19)
-          requestAnimationFrame(() => {
-            if (isScrollToTop) {
+        if (isScrollToTop) {
+          setTimeout(() => {
+            // use requestAnimationFrame to ensure the scroll position is updated (To ensure compatibility react 19)
+            requestAnimationFrame(() => {
               let el = getTargetElement(target);
               el = el === document ? document.documentElement : el;
               if (el) {
                 const scrollHeight = getScrollHeight(el);
                 (el as Element).scrollTo(0, scrollHeight - scrollBottom.current);
               }
-            }
+            });
           });
-        });
-
-        if (!isScrollToTop) {
+        } else {
           shouldScrollCheckRef.current = true;
         }
         onSuccess?.(d.currentData);

--- a/packages/hooks/src/useInfiniteScroll/index.tsx
+++ b/packages/hooks/src/useInfiniteScroll/index.tsx
@@ -32,7 +32,7 @@ const useInfiniteScroll = <TData extends Data>(
   // scrollBottom is used to record the distance from the bottom of the scroll bar
   const scrollBottom = useRef<number>(0);
   // flag: set in onSuccess (bottom direction only) to trigger scrollMethod via effect
-  const shouldScrollCheckRef = useRef(false);
+  const pendingBottomScrollCheckRef = useRef(false);
 
   const noMore = useMemo(() => {
     if (!isNoMore) {
@@ -81,7 +81,7 @@ const useInfiniteScroll = <TData extends Data>(
             });
           });
         } else {
-          shouldScrollCheckRef.current = true;
+          pendingBottomScrollCheckRef.current = true;
         }
         onSuccess?.(d.currentData);
       },
@@ -146,10 +146,10 @@ const useInfiniteScroll = <TData extends Data>(
     }
   };
   useUpdateEffect(() => {
-    if (!shouldScrollCheckRef.current) {
+    if (!pendingBottomScrollCheckRef.current) {
       return;
     }
-    shouldScrollCheckRef.current = false;
+    pendingBottomScrollCheckRef.current = false;
     scrollMethod();
   }, [finalData]);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Before: `onSuccess() -> setFinalData() and scrollMethod() -> loadMore() -> finalData`. 
After: `onSuccess() -> setFinalData()`, ` useEffect() -> scrollMethod() -> loadMore() -> finalData`

The `scrollMethod() -> loadMore() -> finalData` is within the closure of the old flow, causing `loadMore()` to access the old state.



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix closure issue (cannot access the latest data during the first `loadMore()`)       |
| 🇨🇳 Chinese |    修复闭包问题（第一次 `loadMore()` 时无法访问最新数据）      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
