### PR TITLE
fix: (useKeyPress): add legacy key aliases for compatibility with sta…

### DIFF
--- a/packages/hooks/src/useKeyPress/__tests__/index.spec.tsx
+++ b/packages/hooks/src/useKeyPress/__tests__/index.spec.tsx
@@ -16,6 +16,48 @@ describe('useKeyPress ', () => {
     unmount();
   });
 
+  test('test standard key aliases', async () => {
+    const { unmount } = renderHook(() => useKeyPress(['arrowleft', 'escape'], callback));
+    fireEvent.keyDown(document, { key: 'ArrowLeft', keyCode: 37 });
+    fireEvent.keyDown(document, { key: 'Escape', keyCode: 27 });
+    expect(callback.mock.calls.length).toBe(2);
+    unmount();
+  });
+
+  test('test standard vs legacy key aliases', async () => {
+    const aliasCallback = vi.fn();
+    const { unmount } = renderHook(() =>
+      useKeyPress(
+        [
+          'control',
+          'ctrl',
+          'escape',
+          'esc',
+          'arrowleft',
+          'leftarrow',
+          'spacebar',
+          'space',
+          'contextmenu',
+          'selectkey',
+          'pause',
+          'pausebreak',
+        ],
+        aliasCallback,
+      ),
+    );
+
+    fireEvent.keyDown(document, { key: 'Control', keyCode: 17, ctrlKey: true });
+    fireEvent.keyDown(document, { key: 'Escape', keyCode: 27 });
+    fireEvent.keyDown(document, { key: 'ArrowLeft', keyCode: 37 });
+    fireEvent.keyDown(document, { key: ' ', keyCode: 32 });
+    fireEvent.keyDown(document, { key: 'ContextMenu', keyCode: 93 });
+    fireEvent.keyDown(document, { key: 'Pause', keyCode: 19 });
+
+    // each event should match once (first alias hit)
+    expect(aliasCallback.mock.calls.length).toBe(6);
+    unmount();
+  });
+
   test('test modifier key', async () => {
     const { unmount } = renderHook(() => useKeyPress(['ctrl'], callback));
     fireEvent.keyDown(document, { key: 'ctrl', keyCode: 17, ctrlKey: true });

--- a/packages/hooks/src/useKeyPress/index.en-US.md
+++ b/packages/hooks/src/useKeyPress/index.en-US.md
@@ -69,8 +69,7 @@ useKeyPress(
 
 ## Remarks
 
-1. All key alias refer to [code](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useKeyPress/index.ts#L21)
-
+1. Supports part of standard browser key values. Reference: [MDN keyboard key values](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values). Full alias list refers to [code](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useKeyPress/index.ts#L21)
 2. Modifier keys
 
 ```text

--- a/packages/hooks/src/useKeyPress/index.ts
+++ b/packages/hooks/src/useKeyPress/index.ts
@@ -35,20 +35,33 @@ const aliasKeyCodeMap = {
   tab: 9,
   enter: 13,
   shift: 16,
+  // Legacy alias kept for compatibility; standard name is "control".
   ctrl: 17,
+  control: 17,
   alt: 18,
+  // Legacy alias kept for compatibility; standard name is "pause".
   pausebreak: 19,
+  pause: 19,
   capslock: 20,
+  // Legacy alias kept for compatibility; standard name is "escape".
   esc: 27,
+  escape: 27,
+  // Legacy alias kept for compatibility; standard name is "spacebar" (non-standard but widely used).
   space: 32,
+  spacebar: 32,
   pageup: 33,
   pagedown: 34,
   end: 35,
   home: 36,
+  // Legacy aliases kept for compatibility; standard names are "arrowleft/arrowup/arrowright/arrowdown".
   leftarrow: 37,
+  arrowleft: 37,
   uparrow: 38,
+  arrowup: 38,
   rightarrow: 39,
+  arrowright: 39,
   downarrow: 40,
+  arrowdown: 40,
   insert: 45,
   delete: 46,
   a: 65,
@@ -80,7 +93,9 @@ const aliasKeyCodeMap = {
   leftwindowkey: 91,
   rightwindowkey: 92,
   meta: isAppleDevice ? [91, 93] : [91, 92],
+  // Legacy alias kept for compatibility; standard name is "contextmenu".
   selectkey: 93,
+  contextmenu: 93,
   numpad0: 96,
   numpad1: 97,
   numpad2: 98,

--- a/packages/hooks/src/useKeyPress/index.zh-CN.md
+++ b/packages/hooks/src/useKeyPress/index.zh-CN.md
@@ -19,7 +19,7 @@ nav:
 
 ### 精确匹配
 
-<code src="./demo/demo7.tsx">
+<code src="./demo/demo7.tsx" />
 
 ### 监听多个按键
 
@@ -69,8 +69,7 @@ useKeyPress(
 
 ## Remarks
 
-1. 按键别名见 [代码](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useKeyPress/index.ts#L21)
-
+1. 支持部分浏览器标准按键值。参考文档：[MDN 键值表](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values)。完整列表见 [代码](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useKeyPress/index.ts#L21)
 2. 修饰键
 
 ```text


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fixes #2895

### 💡 需求背景和解决方案

**背景**  
`useKeyPress` 的别名映射未覆盖浏览器 `KeyboardEvent.key` 的标准命名（如 `ArrowLeft/ArrowRight`），导致使用标准 key 名称时无法命中。

**解决方案**  
在别名映射中补充对应的标准命名，同时保留原有旧别名以兼容历史使用。

**API 与用法**  
API 不变，仅增强 `keyFilter` 对标准 key 名称的识别能力。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add standard `KeyboardEvent.key` aliases (e.g. `arrowleft`, `arrowright`, etc.) while keeping legacy aliases for backward compatibility. |
| 🇨🇳 中文 | 补充 `KeyboardEvent.key` 的标准别名（如 `arrowleft`/`arrowright` 等），并保留旧别名以兼容历史用法。 |

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须补充
