### PR TITLE
fix: Fixes an issue where the target does not accept the ref type when using explicit generics with useEventListener.

### DIFF
--- a/packages/hooks/src/useEventListener/__tests__/index.spec.ts
+++ b/packages/hooks/src/useEventListener/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import useEventListener from '../index';
 
@@ -79,5 +80,26 @@ describe('useEventListener', () => {
     container.click();
     expect(state).toBe(1);
     unmount();
+  });
+
+  // Type regression guard: this call should type-check when event generic is explicit
+  // and `target` is a ref. Runtime assertion only verifies listener still works.
+  test('should support ref target with explicit event generic', () => {
+    let state = 0;
+    const onScroll = () => {
+      state++;
+    };
+
+    const { unmount } = renderHook(() => {
+      const target = useRef<HTMLDivElement>(container);
+      useEventListener<'scroll'>('scroll', onScroll, { target });
+    });
+
+    container.dispatchEvent(new Event('scroll'));
+    expect(state).toBe(1);
+
+    unmount();
+    container.dispatchEvent(new Event('scroll'));
+    expect(state).toBe(1);
   });
 });

--- a/packages/hooks/src/useEventListener/index.ts
+++ b/packages/hooks/src/useEventListener/index.ts
@@ -7,8 +7,10 @@ type noop = (...p: any) => void;
 
 export type Target = BasicTarget<HTMLElement | Element | Window | Document>;
 
-type Options<T extends Target = Target> = {
-  target?: T;
+type TargetType = HTMLElement | Element | Window | Document;
+
+type Options<T extends TargetType = TargetType> = {
+  target?: BasicTarget<T>;
   capture?: boolean;
   once?: boolean;
   passive?: boolean;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Closes #2902

### 💡 需求背景和解决方案

Issue #2902 中，`useEventListener` 在显式指定事件泛型参数时（例如 `useEventListener<'scroll'>`），`options.target` 的类型推导会退化为 `HTMLElement` 本体，导致 `ref`（如 `RefObject<HTMLDivElement | null>`）无法通过类型检查。

具体修复：
1. 调整 `useEventListener` 内部 `Options<T>` 类型定义：
   - 从 `target?: T`
   - 改为 `target?: BasicTarget<T>`
2. 保持现有运行时逻辑不变，仅修复类型约束语义。
3. 新增回归测试，覆盖“显式泛型 + ref target”场景，防止后续回归。

涉及文件：
- `packages/hooks/src/useEventListener/index.ts`
- `packages/hooks/src/useEventListener/__tests__/index.spec.ts`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fixed `useEventListener` typing to accept `ref` targets when event generic is explicitly specified (e.g. `useEventListener<'scroll'>`). Added a regression test for this scenario. |
| 🇨🇳 中文 | 修复 `useEventListener` 在显式指定事件泛型（如 `useEventListener<'scroll'>`）时 `target` 不能接收 `ref` 的类型问题，并补充对应回归测试。 |

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
