### PR TITLE
fix(useSetState): Supports a default initialState as an empty object.

### DIFF
--- a/packages/hooks/src/useSetState/__tests__/index.spec.ts
+++ b/packages/hooks/src/useSetState/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import useSetState from '../index';
 
 describe('useSetState', () => {
-  const setUp = <T extends object>(initialValue: T) =>
+  const setUp = <T extends object>(initialValue?: T) =>
     renderHook(() => {
       const [state, setState] = useSetState<T>(initialValue);
       return {
@@ -37,5 +37,23 @@ describe('useSetState', () => {
       hook.result.current.setState((prev) => ({ count: prev.count + 1 }));
     });
     expect(hook.result.current.state).toEqual({ count: 1 });
+  });
+
+  test('should support empty initial state', () => {
+    const hook = renderHook(() => {
+      const [state, setState] = useSetState<{ hello?: string }>();
+      return {
+        state,
+        setState,
+      } as const;
+    });
+
+    expect(hook.result.current.state).toEqual({});
+
+    act(() => {
+      hook.result.current.setState({ hello: 'world' });
+    });
+
+    expect(hook.result.current.state).toEqual({ hello: 'world' });
   });
 });

--- a/packages/hooks/src/useSetState/__tests__/index.spec.ts
+++ b/packages/hooks/src/useSetState/__tests__/index.spec.ts
@@ -1,9 +1,9 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from 'vitest';
 import useSetState from '../index';
 
 describe('useSetState', () => {
-  const setUp = <T extends object>(initialValue?: T) =>
+  const setUp = <T extends object>(initialValue: T) =>
     renderHook(() => {
       const [state, setState] = useSetState<T>(initialValue);
       return {
@@ -55,5 +55,14 @@ describe('useSetState', () => {
     });
 
     expect(hook.result.current.state).toEqual({ hello: 'world' });
+  });
+
+  test('should expose empty initial state as partial', () => {
+    const useRequiredState = () => {
+      const [state] = useSetState<{ required: string }>();
+      return state;
+    };
+
+    expectTypeOf(useRequiredState).returns.toEqualTypeOf<{ required?: string }>();
   });
 });

--- a/packages/hooks/src/useSetState/index.en-US.md
+++ b/packages/hooks/src/useSetState/index.en-US.md
@@ -20,7 +20,7 @@ useSetState works similar to `this.setState` of class component, used to manage 
 ## API
 
 ```typescript
-const [state, setState] = useSetState<T>(initialState);
+const [state, setState] = useSetState<T>(initialState?);
 ```
 
 ### Result
@@ -34,4 +34,4 @@ const [state, setState] = useSetState<T>(initialState);
 
 | Property     | Description   | Type           | Default |
 | ------------ | ------------- | -------------- | ------- |
-| initialState | Initial state | `T \| () => T` | -       |
+| initialState | Initial state | `T \| () => T` | `{}`    |

--- a/packages/hooks/src/useSetState/index.en-US.md
+++ b/packages/hooks/src/useSetState/index.en-US.md
@@ -20,15 +20,16 @@ useSetState works similar to `this.setState` of class component, used to manage 
 ## API
 
 ```typescript
-const [state, setState] = useSetState<T>(initialState?);
+const [state, setState] = useSetState<T>(initialState);
+const [partialState, setPartialState] = useSetState<T>();
 ```
 
 ### Result
 
-| Property | Description          | Type                                                                                      | Default |
-| -------- | -------------------- | ----------------------------------------------------------------------------------------- | ------- |
-| state    | Current state        | `T`                                                                                       | -       |
-| setState | Update current state | `(state: Partial<T> \| null) => void` \| `((prevState: T) => Partial<T> \| null) => void` | -       |
+| Property | Description          | Type                                                                                  | Default |
+| -------- | -------------------- | ------------------------------------------------------------------------------------- | ------- |
+| state    | Current state        | `T`; `Partial<T>` when `initialState` is omitted                                      | -       |
+| setState | Update current state | `SetState<T>`; `SetState<Partial<T>>` when `initialState` is omitted                   | -       |
 
 ### Params
 

--- a/packages/hooks/src/useSetState/index.ts
+++ b/packages/hooks/src/useSetState/index.ts
@@ -7,7 +7,7 @@ export type SetState<S extends Record<string, any>> = <K extends keyof S>(
 ) => void;
 
 const useSetState = <S extends Record<string, any>>(
-  initialState: S | (() => S),
+  initialState: S | (() => S) = {} as S,
 ): [S, SetState<S>] => {
   const [state, setState] = useState<S>(initialState);
 

--- a/packages/hooks/src/useSetState/index.ts
+++ b/packages/hooks/src/useSetState/index.ts
@@ -6,10 +6,14 @@ export type SetState<S extends Record<string, any>> = <K extends keyof S>(
   state: Pick<S, K> | null | ((prevState: Readonly<S>) => Pick<S, K> | S | null),
 ) => void;
 
-const useSetState = <S extends Record<string, any>>(
-  initialState: S | (() => S) = {} as S,
-): [S, SetState<S>] => {
-  const [state, setState] = useState<S>(initialState);
+function useSetState<S extends Record<string, any>>(
+  initialState?: undefined,
+): [Partial<S>, SetState<Partial<S>>];
+function useSetState<S extends Record<string, any>>(initialState: S | (() => S)): [S, SetState<S>];
+function useSetState<S extends Record<string, any>>(
+  initialState?: S | (() => S),
+): [Partial<S>, SetState<Partial<S>>] {
+  const [state, setState] = useState<Partial<S>>(initialState ?? {});
 
   const setMergeState = useMemoizedFn((patch) => {
     setState((prevState) => {
@@ -19,6 +23,6 @@ const useSetState = <S extends Record<string, any>>(
   });
 
   return [state, setMergeState];
-};
+}
 
 export default useSetState;

--- a/packages/hooks/src/useSetState/index.zh-CN.md
+++ b/packages/hooks/src/useSetState/index.zh-CN.md
@@ -20,7 +20,7 @@ nav:
 ## API
 
 ```typescript
-const [state, setState] = useSetState<T>(initialState);
+const [state, setState] = useSetState<T>(initialState?);
 ```
 
 ### Result
@@ -34,4 +34,4 @@ const [state, setState] = useSetState<T>(initialState);
 
 | 参数         | 说明     | 类型           | 默认值 |
 | ------------ | -------- | -------------- | ------ |
-| initialState | 初始状态 | `T \| () => T` | -      |
+| initialState | 初始状态 | `T \| () => T` | `{}`   |

--- a/packages/hooks/src/useSetState/index.zh-CN.md
+++ b/packages/hooks/src/useSetState/index.zh-CN.md
@@ -20,15 +20,16 @@ nav:
 ## API
 
 ```typescript
-const [state, setState] = useSetState<T>(initialState?);
+const [state, setState] = useSetState<T>(initialState);
+const [partialState, setPartialState] = useSetState<T>();
 ```
 
 ### Result
 
-| 参数     | 说明         | 类型                                                                                      | 默认值 |
-| -------- | ------------ | ----------------------------------------------------------------------------------------- | ------ |
-| state    | 当前状态     | `T`                                                                                       | -      |
-| setState | 设置当前状态 | `(state: Partial<T> \| null) => void` \| `((prevState: T) => Partial<T> \| null) => void` | -      |
+| 参数     | 说明         | 类型                                                             | 默认值 |
+| -------- | ------------ | ---------------------------------------------------------------- | ------ |
+| state    | 当前状态     | `T`；未传入 `initialState` 时为 `Partial<T>`                     | -      |
+| setState | 设置当前状态 | `SetState<T>`；未传入 `initialState` 时为 `SetState<Partial<T>>` | -      |
 
 ### Params
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Closes #2729
- Issue: https://github.com/alibaba/hooks/issues/2729

### 💡 需求背景和解决方案

`useSetState` 当前要求必须传入 `initialState`，与部分开发者的使用习惯（以及 react-use 的 API）不一致。  
本次改动让 `initialState` 变为可选，并在未传入时默认使用空对象初始化，提升易用性并保持向后兼容。

具体方案：

1. 将 `useSetState` 参数从必填改为可选，默认值为 `{}`（类型层面为 `{} as S`）。
2. 保持现有合并更新语义不变（包含对 `null` patch 的处理逻辑）。
3. 新增测试覆盖无参初始化场景。
4. 同步更新中英文文档 API 描述和默认值说明。

最终 API 与用法：

```ts
const [state, setState] = useSetState<T>(initialState?);

// 支持原有用法
const [state1, setState1] = useSetState({ count: 0 });

// 新增支持：无参初始化
const [state2, setState2] = useSetState<{ hello?: string }>();
setState2({ hello: 'world' });
