### PR TITLE
fix(useLocalStorageState): Add a new SSR secure initialization option.

### DIFF
--- a/packages/hooks/src/createUseStorageState/index.ts
+++ b/packages/hooks/src/createUseStorageState/index.ts
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import useEventListener from '../useEventListener';
 import useMemoizedFn from '../useMemoizedFn';
+import useMount from '../useMount';
 import useUpdateEffect from '../useUpdateEffect';
 import { isFunction, isUndef } from '../utils';
 
@@ -10,6 +11,7 @@ export type SetState<S> = S | ((prevState?: S) => S);
 
 export interface Options<T> {
   defaultValue?: T | (() => T);
+  getInitialValueInEffect?: boolean;
   listenStorageChange?: boolean;
   serializer?: (value: T) => string;
   deserializer?: (value: string) => T;
@@ -19,8 +21,7 @@ export interface Options<T> {
 export const createUseStorageState = (getStorage: () => Storage | undefined) => {
   const useStorageState = <T>(key: string, options: Options<T> = {}) => {
     let storage: Storage | undefined;
-
-    const { listenStorageChange = false } = options;
+    const { listenStorageChange = false, getInitialValueInEffect = false } = options;
 
     const serializer = isFunction(options.serializer) ? options.serializer : JSON.stringify;
 
@@ -44,13 +45,32 @@ export const createUseStorageState = (getStorage: () => Storage | undefined) => 
       } catch (e) {
         onError(e);
       }
+      return getDefaultValue();
+    }
+
+    function getDefaultValue() {
       if (isFunction(options.defaultValue)) {
         return options.defaultValue();
       }
+
       return options.defaultValue;
     };
 
-    const [state, setState] = useState<T>(getStoredValue);
+    const [state, setState] = useState<T>(() => {
+      if (getInitialValueInEffect) {
+        return getDefaultValue();
+      }
+
+      return getStoredValue();
+    });
+
+    useMount(() => {
+      if (!getInitialValueInEffect) {
+        return;
+      }
+
+      setState(getStoredValue());
+    });
 
     const stateRef = useRef<T>(state);
     stateRef.current = state;

--- a/packages/hooks/src/useLocalStorageState/index.en-US.md
+++ b/packages/hooks/src/useLocalStorageState/index.en-US.md
@@ -34,6 +34,7 @@ type SetState<S> = S | ((prevState?: S) => S);
 
 interface Options<T> {
   defaultValue?: T | (() => T);
+  getInitialValueInEffect?: boolean;
   listenStorageChange?: boolean;
   serializer?: (value: T) => string;
   deserializer?: (value: string) => T;
@@ -58,6 +59,7 @@ const [state, setState] = useLocalStorageState<T>(
 | Property            | Description                                                                                                                                                                                             | Type                       | Default                       |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------- |
 | defaultValue        | Default value                                                                                                                                                                                           | `any \| (() => any)`       | -                             |
+| getInitialValueInEffect | Whether to read localStorage in an effect after mount, useful to avoid SSR hydration mismatch                                                                                                      | `boolean`                  | `false`                       |
 | listenStorageChange | Whether to listen storage changes. If `true`, when the stored value changes, all `useLocalStorageState` with the same `key` will synchronize their states, including different tabs of the same browser | `boolean`                  | `false`                       |
 | serializer          | Custom serialization method                                                                                                                                                                             | `(value: any) => string`   | `JSON.stringify`              |
 | deserializer        | Custom deserialization method                                                                                                                                                                           | `(value: string) => any`   | `JSON.parse`                  |

--- a/packages/hooks/src/useLocalStorageState/index.zh-CN.md
+++ b/packages/hooks/src/useLocalStorageState/index.zh-CN.md
@@ -34,6 +34,7 @@ type SetState<S> = S | ((prevState?: S) => S);
 
 interface Options<T> {
   defaultValue?: T | (() => T);
+  getInitialValueInEffect?: boolean;
   listenStorageChange?: boolean;
   serializer?: (value: T) => string;
   deserializer?: (value: string) => T;
@@ -58,6 +59,7 @@ const [state, setState] = useLocalStorageState<T>(
 | 参数                | 说明                                                                                                                              | 类型                       | 默认值                        |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------- |
 | defaultValue        | 默认值                                                                                                                            | `any \| (() => any)`       | -                             |
+| getInitialValueInEffect | 是否在挂载后通过 effect 读取 localStorage，可用于避免 SSR hydration 不一致                                                                 | `boolean`                  | `false`                       |
 | listenStorageChange | 是否监听存储变化。如果是 `true`，当存储值变化时，所有 `key` 相同的 `useLocalStorageState` 会同步状态，包括同一浏览器不同 tab 之间 | `boolean`                  | `false`                       |
 | serializer          | 自定义序列化方法                                                                                                                  | `(value: any) => string`   | `JSON.stringify`              |
 | deserializer        | 自定义反序列化方法                                                                                                                | `(value: string) => any`   | `JSON.parse`                  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Resolves #2856
- Issue: https://github.com/alibaba/hooks/issues/2856

### 💡 需求背景和解决方案

在 SSR 场景中，`useLocalStorageState` 首屏渲染可能出现 hydration mismatch：

- 服务端无法访问 `localStorage`，只能使用 `defaultValue`；
- 客户端首渲染会立即读取 `localStorage`，若值与 `defaultValue` 不一致，可能导致首屏结构不一致并触发 hydration warning/error。

本次方案新增可选参数 `getInitialValueInEffect`（默认 `false`）：

- `false`：保持现有行为（初始化阶段读取 storage）。
- `true`：初始化阶段仅使用 `defaultValue`，在组件挂载后再读取 storage 并更新状态，从而避免 SSR hydration mismatch。

最终 API：

```ts
interface Options<T> {
  defaultValue?: T | (() => T);
  getInitialValueInEffect?: boolean;
  listenStorageChange?: boolean;
  serializer?: (value: T) => string;
  deserializer?: (value: string) => T;
  onError?: (error: unknown) => void;
}
