### PR TITLE
fix(useRequest): Fix type inference for default parameter scenarios

### DIFF
--- a/packages/hooks/src/useRequest/__tests__/index.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/index.spec.ts
@@ -207,12 +207,10 @@ describe('useRequest', () => {
     let value: any = 'init';
 
     await act(async () => {
-      hook.result.current
-        .runAsync(1)
-        .then((res: any) => {
-          resolved = true;
-          value = res;
-        });
+      hook.result.current.runAsync(1).then((res: any) => {
+        resolved = true;
+        value = res;
+      });
       await Promise.resolve();
     });
 
@@ -233,12 +231,10 @@ describe('useRequest', () => {
     value = 'init';
 
     await act(async () => {
-      hook.result.current
-        .runAsync(1)
-        .then((res: any) => {
-          resolved = true;
-          value = res;
-        });
+      hook.result.current.runAsync(1).then((res: any) => {
+        resolved = true;
+        value = res;
+      });
       await Promise.resolve();
     });
 
@@ -263,5 +259,28 @@ describe('useRequest', () => {
     expect(hook.result.current.data).toBe('success');
     expect(hook.result.current.loading).toBe(false);
     hook.unmount();
+  });
+
+  test('should infer default parameter types from service', () => {
+    const service = async (a = 1, b = 1) => {
+      return `${a + b}`;
+    };
+
+    const { result } = renderHook(() =>
+      useRequest(service, {
+        manual: true,
+      }),
+    );
+
+    act(() => {
+      result.current.run(1, 2);
+    });
+
+    const assertRunParamTypes = () => {
+      // @ts-expect-error should reject non-number params
+      result.current.run('1', 2);
+    };
+
+    expect(assertRunParamTypes).toBeDefined();
   });
 });

--- a/packages/hooks/src/useRequest/src/useRequest.ts
+++ b/packages/hooks/src/useRequest/src/useRequest.ts
@@ -6,8 +6,14 @@ import usePollingPlugin from './plugins/usePollingPlugin';
 import useRefreshOnWindowFocusPlugin from './plugins/useRefreshOnWindowFocusPlugin';
 import useRetryPlugin from './plugins/useRetryPlugin';
 import useThrottlePlugin from './plugins/useThrottlePlugin';
-import type { Options, Plugin, Service } from './types';
+import type { Options, Plugin, Result, Service } from './types';
 import useRequestImplement from './useRequestImplement';
+
+type AnyService = (...args: any[]) => Promise<any>;
+
+type InferData<TService extends AnyService> = Awaited<ReturnType<TService>>;
+
+type InferParams<TService extends AnyService> = Parameters<TService>;
 
 // function useRequest<TData, TParams extends any[], TFormated, TTFormated extends TFormated = any>(
 //   service: Service<TData, TParams>,
@@ -19,6 +25,18 @@ import useRequestImplement from './useRequestImplement';
 //   options?: OptionsWithoutFormat<TData, TParams>,
 //   plugins?: Plugin<TData, TParams>[],
 // ): Result<TData, TParams>
+function useRequest<TService extends AnyService>(
+  service: TService,
+  options?: Options<InferData<TService>, InferParams<TService>>,
+  plugins?: Plugin<InferData<TService>, InferParams<TService>>[],
+): Result<InferData<TService>, InferParams<TService>>;
+
+function useRequest<TData, TParams extends any[]>(
+  service: Service<TData, TParams>,
+  options?: Options<TData, TParams>,
+  plugins?: Plugin<TData, TParams>[],
+): Result<TData, TParams>;
+
 function useRequest<TData, TParams extends any[]>(
   service: Service<TData, TParams>,
   options?: Options<TData, TParams>,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Closes #2671
- Issue: https://github.com/alibaba/hooks/issues/2671

### 💡 需求背景和解决方案

`useRequest` 在 service 使用默认参数时（例如 `async (a = 1, b = 1) => {}`），参数类型可能被推导为 `any`，导致 `run/runAsync` 参数约束丢失。

本次改动通过补充函数重载，基于 `service` 自动推导参数与返回值类型：

- 参数类型：`Parameters<TService>`
- 返回值类型：`Awaited<ReturnType<TService>>`

并保留原有泛型签名，确保兼容现有用法。

最终效果：
- `useRequest(async (a = 1, b = 1) => ...)` 时，`run(1, 2)` 类型正确；
- 非法调用如 `run('1', 2)` 会在类型层报错。

同时新增类型回归测试，防止该问题再次出现。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fixed `useRequest` type inference for services with default parameters by adding service-based overload inference (`Parameters`/`Awaited<ReturnType>`). Added a regression test to ensure non-matching `run` params are rejected. |
| 🇨🇳 中文 | 修复 `useRequest` 在默认参数 service 场景下的类型推导问题，新增基于 service 的重载推导（`Parameters` / `Awaited<ReturnType>`），并补充回归测试，确保 `run` 参数类型约束生效。 |

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
