### PR TITLE
fix(useToggle): correct overload typings

### DIFF
--- a/packages/hooks/src/useToggle/__tests__/index.spec.ts
+++ b/packages/hooks/src/useToggle/__tests__/index.spec.ts
@@ -15,14 +15,14 @@ describe('useToggle', () => {
   });
 
   test('test on methods', async () => {
-    const hook = renderHook(() => useToggle('Hello'));
-    expect(hook.result.current[0]).toBe('Hello');
+    const hook = renderHook(() => useToggle(true));
+    expect(hook.result.current[0]).toBeTruthy();
     callToggle(hook);
     expect(hook.result.current[0]).toBeFalsy();
     act(() => {
       hook.result.current[1].setLeft();
     });
-    expect(hook.result.current[0]).toBe('Hello');
+    expect(hook.result.current[0]).toBeTruthy();
     act(() => {
       hook.result.current[1].setRight();
     });

--- a/packages/hooks/src/useToggle/index.en-US.md
+++ b/packages/hooks/src/useToggle/index.en-US.md
@@ -22,17 +22,15 @@ A hook that toggle states.
 ```typescript
 const [state, { toggle, set, setLeft, setRight }] = useToggle(defaultValue?: boolean);
 
-const [state, { toggle, set, setLeft, setRight }] = useToggle<T>(defaultValue: T);
-
 const [state, { toggle, set, setLeft, setRight }] = useToggle<T, U>(defaultValue: T, reverseValue: U)
 ```
 
 ### Params
 
-| Property     | Description                 | Type | Default |
-| ------------ | --------------------------- | ---- | ------- |
-| defaultValue | The default value. Optional | `T`  | `false` |
-| reverseValue | The reverse value. Optional | `U`  | -       |
+| Property     | Description                 | Type           | Default |
+| ------------ | --------------------------- | -------------- | ------- |
+| defaultValue | The default value. Optional | `boolean \| T` | `false` |
+| reverseValue | The reverse value. Optional | `U`            | -       |
 
 ### Result
 

--- a/packages/hooks/src/useToggle/index.ts
+++ b/packages/hooks/src/useToggle/index.ts
@@ -7,9 +7,9 @@ export interface Actions<T> {
   toggle: () => void;
 }
 
-function useToggle<T = boolean>(): [boolean, Actions<T>];
+function useToggle(): [boolean, Actions<boolean>];
 
-function useToggle<T>(defaultValue: T): [T, Actions<T>];
+function useToggle(defaultValue: boolean): [boolean, Actions<boolean>];
 
 function useToggle<T, U>(defaultValue: T, reverseValue: U): [T | U, Actions<T | U>];
 

--- a/packages/hooks/src/useToggle/index.zh-CN.md
+++ b/packages/hooks/src/useToggle/index.zh-CN.md
@@ -22,17 +22,15 @@ nav:
 ```typescript
 const [state, { toggle, set, setLeft, setRight }] = useToggle(defaultValue?: boolean);
 
-const [state, { toggle, set, setLeft, setRight }] = useToggle<T>(defaultValue: T);
-
 const [state, { toggle, set, setLeft, setRight }] = useToggle<T, U>(defaultValue: T, reverseValue: U);
 ```
 
 ### Params
 
-| 参数         | 说明                     | 类型 | 默认值  |
-| ------------ | ------------------------ | ---- | ------- |
-| defaultValue | 可选项，传入默认的状态值 | `T`  | `false` |
-| reverseValue | 可选项，传入取反的状态值 | `U`  | -       |
+| 参数         | 说明                     | 类型           | 默认值  |
+| ------------ | ------------------------ | -------------- | ------- |
+| defaultValue | 可选项，传入默认的状态值 | `boolean \| T` | `false` |
+| reverseValue | 可选项，传入取反的状态值 | `U`            | -       |
 
 ### Result
 


### PR DESCRIPTION
Align useToggle overloads with runtime behavior.
- no-argument usage returns boolean
- one-argument usage only supports boolean
- custom toggle values are inferred only when both defaultValue and reverseValue are provided

<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/alibaba/hooks/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
None
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->
This PR aligns `useToggle` overload typings with its runtime behavior.

Previously, the no-argument overload exposed an unnecessary generic type, which could lead to inconsistent typing between the returned state and actions.

For example:
```
const [state, actions] = useToggle<string>();
actions.set('open');
```

In this case, TypeScript previously allowed actions.set to receive a `string`, while state was still typed as `boolean`. This made the action typings inconsistent with the actual state type.

Also, when only `defaultValue` was provided with a non-boolean value, TypeScript inferred the state as the original value type. However, at runtime, `reverseValue` defaults to `!defaultValue`, which means the actual state may become `boolean`.

For example:
```
const [state, actions] = useToggle('open');
actions.toggle();
```
In this case, TypeScript previously inferred state as `string`, but the runtime value could become `false`.


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `useToggle` overload typings to align with runtime behavior. |
| 🇨🇳 Chinese | 修复 `useToggle` 函数重载类型，使其与运行时行为保持一致。|

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
