### PR TITLE
fix: reset debounce when request is not ready (#2581)

### DIFF
--- a/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
@@ -74,7 +74,7 @@ describe('useDebouncePlugin', () => {
     hook.unmount();
   });
 
-  test('useDebouncePlugin should reset leading debounce when ready becomes false', () => {
+  test('useDebouncePlugin should bypass debounce when ready is false', () => {
     vi.useFakeTimers();
     const callback = vi.fn();
 
@@ -99,6 +99,12 @@ describe('useDebouncePlugin', () => {
       debounceWait: 100,
       debounceLeading: true,
     });
+
+    act(() => {
+      hook.result.current.run();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
 
     act(() => {
       vi.advanceTimersByTime(50);

--- a/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
@@ -73,4 +73,45 @@ describe('useDebouncePlugin', () => {
 
     hook.unmount();
   });
+
+  test('useDebouncePlugin should reset leading debounce when ready becomes false', () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+
+    act(() => {
+      hook = setUp(
+        () => {
+          callback();
+          return request({});
+        },
+        {
+          ready: true,
+          debounceWait: 100,
+          debounceLeading: true,
+        },
+      );
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    hook.rerender({
+      ready: false,
+      debounceWait: 100,
+      debounceLeading: true,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    hook.rerender({
+      ready: true,
+      debounceWait: 100,
+      debounceLeading: true,
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    hook.unmount();
+  });
 });

--- a/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
@@ -1,11 +1,12 @@
 import type { DebouncedFunc, DebounceSettings } from 'lodash';
 import debounce from 'lodash/debounce';
 import { useEffect, useMemo, useRef } from 'react';
+import useUpdateEffect from '../../../useUpdateEffect';
 import type { Plugin } from '../types';
 
 const useDebouncePlugin: Plugin<any, any[]> = (
   fetchInstance,
-  { debounceWait, debounceLeading, debounceTrailing, debounceMaxWait },
+  { debounceWait, debounceLeading, debounceTrailing, debounceMaxWait, ready },
 ) => {
   const debouncedRef = useRef<DebouncedFunc<any>>(undefined);
 
@@ -52,7 +53,13 @@ const useDebouncePlugin: Plugin<any, any[]> = (
         fetchInstance.runAsync = _originRunAsync;
       };
     }
-  }, [debounceWait, options]);
+  }, [debounceWait, options, fetchInstance]);
+
+  useUpdateEffect(() => {
+    if (ready === false) {
+      debouncedRef.current?.cancel();
+    }
+  }, [ready]);
 
   if (!debounceWait) {
     return {};

--- a/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
@@ -39,6 +39,10 @@ const useDebouncePlugin: Plugin<any, any[]> = (
       // debounce runAsync should be promise
       // https://github.com/lodash/lodash/issues/4400#issuecomment-834800398
       fetchInstance.runAsync = (...args) => {
+        if (fetchInstance.options.ready === false) {
+          return _originRunAsync(...args);
+        }
+
         return new Promise<void>((resolve, reject) => {
           debouncedRef.current?.(() => {
             _originRunAsync(...args)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fix #2581

### 💡 Background and solution

When `useRequest` is used with `ready` and `debounceLeading`, the pending debounce window may remain active after `ready` becomes `false`.

If `ready` turns back to `true` before that debounce window ends, the next auto run may not trigger immediately as expected by `debounceLeading`.

This PR cancels the current debounce window when `ready` becomes `false`, so the next `ready=true` auto run can trigger immediately with `debounceLeading`.

A test case is added for the `ready + debounceLeading` scenario.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `useRequest` may not trigger immediately when `ready` is used with `debounceLeading`. |
| 🇨🇳 Chinese | 修复 `useRequest` 同时使用 `ready` 和 `debounceLeading` 时可能无法立即触发请求的问题。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed