### PR TITLE
fix: support pointer events in useLongPress

### DIFF
--- a/packages/hooks/src/useLongPress/__tests__/index.spec.ts
+++ b/packages/hooks/src/useLongPress/__tests__/index.spec.ts
@@ -24,12 +24,46 @@ describe('useLongPress', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    vi.stubGlobal('PointerEvent', undefined);
   });
 
   afterEach(() => {
     events = {};
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  test('uses pointer events when available', () => {
+    class MockPointerEvent extends MouseEvent {
+      isPrimary: boolean;
+
+      constructor(type: string, eventInitDict?: MouseEventInit & { isPrimary?: boolean }) {
+        super(type, eventInitDict);
+        this.isPrimary = eventInitDict?.isPrimary ?? true;
+      }
+    }
+
+    vi.stubGlobal('PointerEvent', MockPointerEvent);
+
+    setup(mockCallback, mockTarget, {
+      onClick: mockClickCallback,
+      onLongPressEnd: mockLongPressEndCallback,
+    });
+    expect(events.pointerdown).toBeDefined();
+    expect(events.pointerup).toBeDefined();
+    expect(events.mousedown).toBeUndefined();
+
+    events.pointerdown(new PointerEvent('pointerdown'));
+    vi.advanceTimersByTime(350);
+    events.pointerup(new PointerEvent('pointerup'));
+
+    events.pointerdown(new PointerEvent('pointerdown'));
+    events.pointerup(new PointerEvent('pointerup'));
+
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockLongPressEndCallback).toHaveBeenCalledTimes(1);
+    expect(mockClickCallback).toHaveBeenCalledTimes(1);
   });
 
   test('longPress callback correct', () => {

--- a/packages/hooks/src/useLongPress/__tests__/index.spec.ts
+++ b/packages/hooks/src/useLongPress/__tests__/index.spec.ts
@@ -20,6 +20,17 @@ const mockTarget = {
 const setup = (onLongPress: any, target: any, options?: Options) =>
   renderHook(() => useLongPress(onLongPress, target, options));
 
+class MockPointerEvent extends MouseEvent {
+  isPrimary: boolean;
+  pointerId: number;
+
+  constructor(type: string, eventInitDict?: PointerEventInit) {
+    super(type, eventInitDict);
+    this.isPrimary = eventInitDict?.isPrimary ?? true;
+    this.pointerId = eventInitDict?.pointerId ?? 0;
+  }
+}
+
 describe('useLongPress', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -35,15 +46,6 @@ describe('useLongPress', () => {
   });
 
   test('uses pointer events when available', () => {
-    class MockPointerEvent extends MouseEvent {
-      isPrimary: boolean;
-
-      constructor(type: string, eventInitDict?: MouseEventInit & { isPrimary?: boolean }) {
-        super(type, eventInitDict);
-        this.isPrimary = eventInitDict?.isPrimary ?? true;
-      }
-    }
-
     vi.stubGlobal('PointerEvent', MockPointerEvent);
 
     setup(mockCallback, mockTarget, {
@@ -64,6 +66,26 @@ describe('useLongPress', () => {
     expect(mockCallback).toHaveBeenCalledTimes(1);
     expect(mockLongPressEndCallback).toHaveBeenCalledTimes(1);
     expect(mockClickCallback).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores events from a different pointer', () => {
+    vi.stubGlobal('PointerEvent', MockPointerEvent);
+
+    setup(mockCallback, mockTarget, {
+      moveThreshold: { x: 30 },
+      onClick: mockClickCallback,
+      onLongPressEnd: mockLongPressEndCallback,
+    });
+
+    events.pointerdown(new PointerEvent('pointerdown', { pointerId: 10 }));
+    events.pointermove(new PointerEvent('pointermove', { clientX: 40, pointerId: 1 }));
+    events.pointerup(new PointerEvent('pointerup', { pointerId: 1 }));
+    vi.advanceTimersByTime(350);
+    events.pointerup(new PointerEvent('pointerup', { pointerId: 10 }));
+
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockLongPressEndCallback).toHaveBeenCalledTimes(1);
+    expect(mockClickCallback).not.toHaveBeenCalled();
   });
 
   test('longPress callback correct', () => {

--- a/packages/hooks/src/useLongPress/index.ts
+++ b/packages/hooks/src/useLongPress/index.ts
@@ -25,6 +25,7 @@ function useLongPress(
 
   const isTriggeredRef = useRef(false);
   const pervPositionRef = useRef({ x: 0, y: 0 });
+  const pointerPressed = useRef(false);
   const mousePressed = useRef(false);
   const touchPressed = useRef(false);
   const hasMoveThreshold = !!(
@@ -38,6 +39,8 @@ function useLongPress(
       if (!targetElement?.addEventListener) {
         return;
       }
+      const supportPointerEvent =
+        typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
 
       const overThreshold = (event: EventType) => {
         const { clientX, clientY } = getClientPosition(event);
@@ -74,6 +77,53 @@ function useLongPress(
         }, delay);
       };
 
+      const clearTimer = () => {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = undefined;
+        }
+      };
+
+      const finishPress = (event: EventType, triggerClick = true) => {
+        clearTimer();
+
+        if (isTriggeredRef.current) {
+          onLongPressEndRef.current?.(event);
+        } else if (triggerClick && onClickRef.current) {
+          onClickRef.current(event);
+        }
+        isTriggeredRef.current = false;
+      };
+
+      const onPointerDown = (event: PointerEvent) => {
+        if (pointerPressed.current || event.isPrimary === false) {
+          return;
+        }
+        pointerPressed.current = true;
+
+        if (hasMoveThreshold) {
+          pervPositionRef.current.x = event.clientX;
+          pervPositionRef.current.y = event.clientY;
+        }
+        createTimer(event);
+      };
+
+      const onPointerUp = (event: PointerEvent) => {
+        if (!pointerPressed.current || event.isPrimary === false) {
+          return;
+        }
+        pointerPressed.current = false;
+        finishPress(event);
+      };
+
+      const onPointerCancel = (event: PointerEvent) => {
+        if (!pointerPressed.current || event.isPrimary === false) {
+          return;
+        }
+        pointerPressed.current = false;
+        finishPress(event, false);
+      };
+
       const onTouchStart = (event: TouchEvent) => {
         if (touchPressed.current) {
           return;
@@ -104,8 +154,7 @@ function useLongPress(
 
       const onMove = (event: EventType) => {
         if (timerRef.current && overThreshold(event)) {
-          clearTimeout(timerRef.current);
-          timerRef.current = undefined;
+          clearTimer();
         }
       };
 
@@ -115,17 +164,7 @@ function useLongPress(
         }
         touchPressed.current = false;
 
-        if (timerRef.current) {
-          clearTimeout(timerRef.current);
-          timerRef.current = undefined;
-        }
-
-        if (isTriggeredRef.current) {
-          onLongPressEndRef.current?.(event);
-        } else if (onClickRef.current) {
-          onClickRef.current(event);
-        }
-        isTriggeredRef.current = false;
+        finishPress(event);
       };
 
       const onMouseUp = (event: MouseEvent) => {
@@ -137,17 +176,7 @@ function useLongPress(
         }
         mousePressed.current = false;
 
-        if (timerRef.current) {
-          clearTimeout(timerRef.current);
-          timerRef.current = undefined;
-        }
-
-        if (isTriggeredRef.current) {
-          onLongPressEndRef.current?.(event);
-        } else if (onClickRef.current) {
-          onClickRef.current(event);
-        }
-        isTriggeredRef.current = false;
+        finishPress(event);
       };
 
       const onMouseLeave = (event: MouseEvent) => {
@@ -156,14 +185,40 @@ function useLongPress(
         }
         mousePressed.current = false;
 
-        if (timerRef.current) {
-          clearTimeout(timerRef.current);
-          timerRef.current = undefined;
+        finishPress(event, false);
+      };
+
+      if (supportPointerEvent) {
+        targetElement.addEventListener('pointerdown', onPointerDown as EventListener);
+        targetElement.addEventListener('pointerup', onPointerUp as EventListener);
+        targetElement.addEventListener('pointerleave', onPointerCancel as EventListener);
+        targetElement.addEventListener('pointercancel', onPointerCancel as EventListener);
+
+        if (hasMoveThreshold) {
+          targetElement.addEventListener('pointermove', onMove as EventListener);
         }
-        if (isTriggeredRef.current) {
-          onLongPressEndRef.current?.(event);
+
+        return () => {
+          clearTimer();
           isTriggeredRef.current = false;
+
+          targetElement.removeEventListener('pointerdown', onPointerDown as EventListener);
+          targetElement.removeEventListener('pointerup', onPointerUp as EventListener);
+          targetElement.removeEventListener('pointerleave', onPointerCancel as EventListener);
+          targetElement.removeEventListener('pointercancel', onPointerCancel as EventListener);
+
+          if (hasMoveThreshold) {
+            targetElement.removeEventListener('pointermove', onMove as EventListener);
+          }
+        };
+      }
+
+      const onTouchCancel = (event: TouchEvent) => {
+        if (!touchPressed.current) {
+          return;
         }
+        touchPressed.current = false;
+        finishPress(event, false);
       };
 
       targetElement.addEventListener('mousedown', onMouseDown as EventListener);
@@ -171,6 +226,7 @@ function useLongPress(
       targetElement.addEventListener('mouseleave', onMouseLeave as EventListener);
       targetElement.addEventListener('touchstart', onTouchStart as EventListener);
       targetElement.addEventListener('touchend', onTouchEnd as EventListener);
+      targetElement.addEventListener('touchcancel', onTouchCancel as EventListener);
 
       if (hasMoveThreshold) {
         targetElement.addEventListener('mousemove', onMove as EventListener);
@@ -178,16 +234,15 @@ function useLongPress(
       }
 
       return () => {
-        if (timerRef.current) {
-          clearTimeout(timerRef.current);
-          isTriggeredRef.current = false;
-        }
+        clearTimer();
+        isTriggeredRef.current = false;
 
         targetElement.removeEventListener('mousedown', onMouseDown as EventListener);
         targetElement.removeEventListener('mouseup', onMouseUp as EventListener);
         targetElement.removeEventListener('mouseleave', onMouseLeave as EventListener);
         targetElement.removeEventListener('touchstart', onTouchStart as EventListener);
         targetElement.removeEventListener('touchend', onTouchEnd as EventListener);
+        targetElement.removeEventListener('touchcancel', onTouchCancel as EventListener);
 
         if (hasMoveThreshold) {
           targetElement.removeEventListener('mousemove', onMove as EventListener);

--- a/packages/hooks/src/useLongPress/index.ts
+++ b/packages/hooks/src/useLongPress/index.ts
@@ -25,7 +25,7 @@ function useLongPress(
 
   const isTriggeredRef = useRef(false);
   const pervPositionRef = useRef({ x: 0, y: 0 });
-  const pointerPressed = useRef(false);
+  const activePointerIdRef = useRef<number>(undefined);
   const mousePressed = useRef(false);
   const touchPressed = useRef(false);
   const hasMoveThreshold = !!(
@@ -96,10 +96,10 @@ function useLongPress(
       };
 
       const onPointerDown = (event: PointerEvent) => {
-        if (pointerPressed.current || event.isPrimary === false) {
+        if (activePointerIdRef.current !== undefined || event.isPrimary === false) {
           return;
         }
-        pointerPressed.current = true;
+        activePointerIdRef.current = event.pointerId;
 
         if (hasMoveThreshold) {
           pervPositionRef.current.x = event.clientX;
@@ -109,19 +109,25 @@ function useLongPress(
       };
 
       const onPointerUp = (event: PointerEvent) => {
-        if (!pointerPressed.current || event.isPrimary === false) {
+        if (activePointerIdRef.current !== event.pointerId) {
           return;
         }
-        pointerPressed.current = false;
+        activePointerIdRef.current = undefined;
         finishPress(event);
       };
 
       const onPointerCancel = (event: PointerEvent) => {
-        if (!pointerPressed.current || event.isPrimary === false) {
+        if (activePointerIdRef.current !== event.pointerId) {
           return;
         }
-        pointerPressed.current = false;
+        activePointerIdRef.current = undefined;
         finishPress(event, false);
+      };
+
+      const onPointerMove = (event: PointerEvent) => {
+        if (activePointerIdRef.current === event.pointerId) {
+          onMove(event);
+        }
       };
 
       const onTouchStart = (event: TouchEvent) => {
@@ -195,12 +201,13 @@ function useLongPress(
         targetElement.addEventListener('pointercancel', onPointerCancel as EventListener);
 
         if (hasMoveThreshold) {
-          targetElement.addEventListener('pointermove', onMove as EventListener);
+          targetElement.addEventListener('pointermove', onPointerMove as EventListener);
         }
 
         return () => {
           clearTimer();
           isTriggeredRef.current = false;
+          activePointerIdRef.current = undefined;
 
           targetElement.removeEventListener('pointerdown', onPointerDown as EventListener);
           targetElement.removeEventListener('pointerup', onPointerUp as EventListener);
@@ -208,7 +215,7 @@ function useLongPress(
           targetElement.removeEventListener('pointercancel', onPointerCancel as EventListener);
 
           if (hasMoveThreshold) {
-            targetElement.removeEventListener('pointermove', onMove as EventListener);
+            targetElement.removeEventListener('pointermove', onPointerMove as EventListener);
           }
         };
       }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### Related issue link

Fixes #2861

### Background and solution

`useLongPress` previously listened to mouse and touch events only. In environments such as Tauri WebView on macOS, pointer events can be delivered while the mouse/touch path is unreliable, so long press never starts.

This change uses PointerEvent listeners when they are supported and keeps the existing mouse/touch listeners as a fallback for older environments. The pointer path shares the same click/long-press-end behavior as the fallback path and also clears pending presses on pointer leave/cancel.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| English | Add PointerEvent support to `useLongPress` while preserving mouse/touch fallback behavior. |
| Chinese | `useLongPress` 支持 PointerEvent，同时保留 mouse/touch 兜底行为。 |

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Test

- `pnpm exec vitest run src/useLongPress/__tests__/index.spec.ts` from `packages/hooks`
- `pnpm --filter=ahooks tsc`
- `pnpm --filter=ahooks test`
