### PR TITLE
fix(useRequest): settle runAsync when superseded instead of hanging

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -48,7 +48,7 @@ import useRafInterval from './useRafInterval';
 import useRafState from './useRafState';
 import useRafTimeout from './useRafTimeout';
 import useReactive from './useReactive';
-import useRequest, { clearCache } from './useRequest';
+import useRequest, { CancelledError, clearCache, isCancelledError } from './useRequest';
 import useResetState from './useResetState';
 import useResponsive, { configResponsive } from './useResponsive';
 import useSafeState from './useSafeState';
@@ -151,6 +151,8 @@ export {
   useInfiniteScroll,
   useGetState,
   clearCache,
+  CancelledError,
+  isCancelledError,
   useFocusWithin,
   createUpdateEffect,
   useRafInterval,

--- a/packages/hooks/src/useRequest/__tests__/index.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { act, type RenderHookResult, renderHook } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { request } from '../../utils/testingHelpers';
-import useRequest from '../index';
+import useRequest, { CancelledError, isCancelledError } from '../index';
 
 const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -244,64 +244,158 @@ describe('useRequest', () => {
     hook.unmount();
   });
 
-  test('runAsync should settle (not hang) when superseded by a newer call', async () => {
-    act(() => {
-      hook = setUp(request, { manual: true });
+  // a service whose settle order is controlled by the caller
+  const delayedRequest = (value: string, delay: number) =>
+    new Promise<string>((resolve) => {
+      setTimeout(() => resolve(value), delay);
     });
 
-    let firstSettled = false;
-    let firstRejected = false;
+  test('runAsync should reject with a CancelledError when cancel is called', async () => {
+    const onError = vi.fn();
+    act(() => {
+      hook = setUp(request, { manual: true, onError });
+    });
+
+    const onFulfilled = vi.fn();
+    const onRejected = vi.fn();
+    const onFinally = vi.fn();
 
     await act(async () => {
-      // start a call, then immediately supersede it with a newer one
-      hook.result.current.runAsync(1).then(
-        () => {
-          firstSettled = true;
-        },
-        () => {
-          firstSettled = true;
-          firstRejected = true;
-        },
-      );
+      hook.result.current.runAsync(1).then(onFulfilled).catch(onRejected).finally(onFinally);
+      hook.result.current.cancel();
+      vi.advanceTimersByTime(1000);
+    });
+
+    // before the fix the cancelled call stayed pending forever, so nothing below ran
+    expect(onFulfilled).not.toHaveBeenCalled();
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0][0]).toBeInstanceOf(CancelledError);
+    expect(onRejected.mock.calls[0][0]).toMatchObject({
+      name: 'CancelledError',
+      message: 'useRequest: the request was cancelled or superseded.',
+    });
+    expect(onFinally).toHaveBeenCalledTimes(1);
+    // cancellation is not a failure: it reaches neither onError nor the error state
+    expect(onError).not.toHaveBeenCalled();
+    expect(hook.result.current.error).toBeUndefined();
+    expect(hook.result.current.data).toBeUndefined();
+    expect(hook.result.current.loading).toBe(false);
+    hook.unmount();
+  });
+
+  test('isCancelledError should recognize only a true cancellation marker', () => {
+    expect(isCancelledError(new CancelledError())).toBe(true);
+    expect(isCancelledError({ __AHOOKS_CANCELLED_ERROR__: true })).toBe(true);
+    expect(isCancelledError({ __AHOOKS_CANCELLED_ERROR__: false })).toBe(false);
+    expect(isCancelledError(new Error('fail'))).toBe(false);
+  });
+
+  test('runAsync should reject the superseded call that settles first', async () => {
+    act(() => {
+      hook = setUp<string, [string, number]>(delayedRequest, { manual: true });
+    });
+
+    const onFirstFulfilled = vi.fn();
+    const onFirstRejected = vi.fn();
+    const onSecondFulfilled = vi.fn();
+
+    await act(async () => {
+      hook.result.current.runAsync('first', 500).then(onFirstFulfilled, onFirstRejected);
+      hook.result.current.runAsync('second', 1000).then(onSecondFulfilled);
+      // only the superseded call has settled by now
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onFirstFulfilled).not.toHaveBeenCalled();
+    expect(onFirstRejected).toHaveBeenCalledTimes(1);
+    expect(isCancelledError(onFirstRejected.mock.calls[0][0])).toBe(true);
+    // the loser publishes nothing, so `data` is not its value either
+    expect(hook.result.current.data).toBeUndefined();
+    expect(hook.result.current.loading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSecondFulfilled).toHaveBeenCalledWith('second');
+    expect(hook.result.current.data).toBe('second');
+    expect(hook.result.current.loading).toBe(false);
+    hook.unmount();
+  });
+
+  test('runAsync should reject the superseded call that settles last', async () => {
+    act(() => {
+      hook = setUp<string, [string, number]>(delayedRequest, { manual: true });
+    });
+
+    const onFirstFulfilled = vi.fn();
+    const onFirstRejected = vi.fn();
+    const onSecondFulfilled = vi.fn();
+
+    await act(async () => {
+      hook.result.current.runAsync('first', 1000).then(onFirstFulfilled, onFirstRejected);
+      hook.result.current.runAsync('second', 200).then(onSecondFulfilled);
+      // only the winning call has settled by now
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onSecondFulfilled).toHaveBeenCalledWith('second');
+    expect(hook.result.current.data).toBe('second');
+    expect(onFirstRejected).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(onFirstFulfilled).not.toHaveBeenCalled();
+    expect(onFirstRejected).toHaveBeenCalledTimes(1);
+    expect(isCancelledError(onFirstRejected.mock.calls[0][0])).toBe(true);
+    // the late loser must not overwrite the winner's data
+    expect(hook.result.current.data).toBe('second');
+    hook.unmount();
+  });
+
+  test('runAsync should report a superseded rejection as cancelled, not as the service error', async () => {
+    const onError = vi.fn();
+    act(() => {
+      hook = setUp(request, { manual: true, onError });
+    });
+
+    const onFirstFulfilled = vi.fn();
+    const onFirstRejected = vi.fn();
+
+    await act(async () => {
+      // the first call rejects with `new Error('fail')`, but a newer call supersedes it
+      hook.result.current.runAsync(0).then(onFirstFulfilled, onFirstRejected);
       hook.result.current.runAsync(2);
       vi.advanceTimersByTime(1000);
     });
 
-    // before the fix the superseded call stayed pending forever
-    expect(firstSettled).toBe(true);
-    expect(firstRejected).toBe(false);
+    expect(onFirstFulfilled).not.toHaveBeenCalled();
+    expect(onFirstRejected).toHaveBeenCalledTimes(1);
+    expect(isCancelledError(onFirstRejected.mock.calls[0][0])).toBe(true);
+    // the stale error reaches neither the caller, nor onError, nor the state
+    expect(onFirstRejected.mock.calls[0][0]).not.toEqual(new Error('fail'));
+    expect(onError).not.toHaveBeenCalled();
+    expect(hook.result.current.error).toBeUndefined();
     expect(hook.result.current.data).toBe('success');
     hook.unmount();
   });
 
-  test('runAsync should settle (not hang) when a superseded call rejects', async () => {
+  test('run should stay silent when the request is cancelled', async () => {
+    errorSpy.mockClear();
     act(() => {
+      // no onError, so `run` would fall back to console.error for a real failure
       hook = setUp(request, { manual: true });
     });
 
-    let firstSettled = false;
-    let firstRejected = false;
-
     await act(async () => {
-      // first call will reject (req === 0), but a newer call supersedes it
-      hook.result.current.runAsync(0).then(
-        () => {
-          firstSettled = true;
-        },
-        () => {
-          firstSettled = true;
-          firstRejected = true;
-        },
-      );
-      hook.result.current.runAsync(2);
+      hook.result.current.run(1);
+      hook.result.current.cancel();
       vi.advanceTimersByTime(1000);
     });
 
-    // the superseded call must not hang; the stale error is dropped, it resolves
-    expect(firstSettled).toBe(true);
-    expect(firstRejected).toBe(false);
-    // state is untouched by the superseded call — the newer call wins
-    expect(hook.result.current.data).toBe('success');
+    expect(errorSpy).not.toHaveBeenCalled();
     hook.unmount();
   });
 

--- a/packages/hooks/src/useRequest/__tests__/index.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/index.spec.ts
@@ -244,6 +244,67 @@ describe('useRequest', () => {
     hook.unmount();
   });
 
+  test('runAsync should settle (not hang) when superseded by a newer call', async () => {
+    act(() => {
+      hook = setUp(request, { manual: true });
+    });
+
+    let firstSettled = false;
+    let firstRejected = false;
+
+    await act(async () => {
+      // start a call, then immediately supersede it with a newer one
+      hook.result.current.runAsync(1).then(
+        () => {
+          firstSettled = true;
+        },
+        () => {
+          firstSettled = true;
+          firstRejected = true;
+        },
+      );
+      hook.result.current.runAsync(2);
+      vi.advanceTimersByTime(1000);
+    });
+
+    // before the fix the superseded call stayed pending forever
+    expect(firstSettled).toBe(true);
+    expect(firstRejected).toBe(false);
+    expect(hook.result.current.data).toBe('success');
+    hook.unmount();
+  });
+
+  test('runAsync should settle (not hang) when a superseded call rejects', async () => {
+    act(() => {
+      hook = setUp(request, { manual: true });
+    });
+
+    let firstSettled = false;
+    let firstRejected = false;
+
+    await act(async () => {
+      // first call will reject (req === 0), but a newer call supersedes it
+      hook.result.current.runAsync(0).then(
+        () => {
+          firstSettled = true;
+        },
+        () => {
+          firstSettled = true;
+          firstRejected = true;
+        },
+      );
+      hook.result.current.runAsync(2);
+      vi.advanceTimersByTime(1000);
+    });
+
+    // the superseded call must not hang; the stale error is dropped, it resolves
+    expect(firstSettled).toBe(true);
+    expect(firstRejected).toBe(false);
+    // state is untouched by the superseded call — the newer call wins
+    expect(hook.result.current.data).toBe('success');
+    hook.unmount();
+  });
+
   test('useRequest defaultParams should work', async () => {
     act(() => {
       hook = setUp<string, [number, number, number]>(request, {

--- a/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
@@ -203,4 +203,28 @@ describe('useDebouncePlugin', () => {
     expect(callback).toHaveBeenCalledTimes(2);
     hook.unmount();
   });
+
+  test('runAsync should reject a call suppressed when trailing is false', async () => {
+    vi.useFakeTimers();
+    const service = vi.fn((value: string) => Promise.resolve(value));
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        debounceWait: 100,
+        debounceLeading: true,
+        debounceTrailing: false,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      await expect(hook.result.current.runAsync('first')).resolves.toBe('first');
+      await expect(hook.result.current.runAsync('dropped')).rejects.toBeInstanceOf(CancelledError);
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(service).toHaveBeenCalledTimes(1);
+    hook.unmount();
+  });
 });

--- a/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useDebouncePlugin.spec.ts
@@ -1,7 +1,7 @@
 import { act, type RenderHookResult, renderHook } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { request } from '../../utils/testingHelpers';
-import useRequest from '../index';
+import useRequest, { CancelledError } from '../index';
 
 describe('useDebouncePlugin', () => {
   const setUp = (
@@ -71,6 +71,59 @@ describe('useDebouncePlugin', () => {
     });
     expect(callback).toHaveBeenCalledTimes(2);
 
+    hook.unmount();
+  });
+
+  test('runAsync should reject a queued call when cancel is called', async () => {
+    vi.useFakeTimers();
+    const service = vi.fn().mockResolvedValue('success');
+    const onRejected = vi.fn();
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        debounceWait: 100,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      hook.result.current.runAsync().catch(onRejected);
+      hook.result.current.cancel();
+      vi.runAllTimers();
+    });
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0][0]).toBeInstanceOf(CancelledError);
+    expect(service).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  test('runAsync should reject a queued call when it is superseded', async () => {
+    vi.useFakeTimers();
+    const service = vi.fn((value: string) => Promise.resolve(value));
+    const onFirstRejected = vi.fn();
+    const onSecondFulfilled = vi.fn();
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        debounceWait: 100,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      hook.result.current.runAsync('first').catch(onFirstRejected);
+      hook.result.current.runAsync('second').then(onSecondFulfilled);
+      vi.runAllTimers();
+    });
+
+    expect(onFirstRejected).toHaveBeenCalledTimes(1);
+    expect(onFirstRejected.mock.calls[0][0]).toBeInstanceOf(CancelledError);
+    expect(service).toHaveBeenCalledTimes(1);
+    expect(service).toHaveBeenCalledWith('second');
+    expect(onSecondFulfilled).toHaveBeenCalledWith('second');
     hook.unmount();
   });
 });

--- a/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.spec.ts
@@ -94,4 +94,26 @@ describe('useThrottlePlugin', () => {
     expect(onSecondFulfilled).toHaveBeenCalledWith('second');
     hook.unmount();
   });
+
+  test('runAsync should reject a call suppressed when trailing is false', async () => {
+    const service = vi.fn((value: string) => Promise.resolve(value));
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        throttleWait: 100,
+        throttleTrailing: false,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      await expect(hook.result.current.runAsync('first')).resolves.toBe('first');
+      await expect(hook.result.current.runAsync('dropped')).rejects.toBeInstanceOf(CancelledError);
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(service).toHaveBeenCalledTimes(1);
+    hook.unmount();
+  });
 });

--- a/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.spec.ts
+++ b/packages/hooks/src/useRequest/__tests__/useThrottlePlugin.spec.ts
@@ -1,7 +1,7 @@
 import { act, type RenderHookResult, renderHook } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { request } from '../../utils/testingHelpers';
-import useRequest from '../index';
+import useRequest, { CancelledError } from '../index';
 
 describe('useThrottlePlugin', () => {
   vi.useFakeTimers();
@@ -40,5 +40,58 @@ describe('useThrottlePlugin', () => {
     });
 
     expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test('runAsync should reject a queued call when cancel is called', async () => {
+    const service = vi.fn().mockResolvedValue('success');
+    const onRejected = vi.fn();
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        throttleWait: 100,
+        throttleLeading: false,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      hook.result.current.runAsync().catch(onRejected);
+      hook.result.current.cancel();
+      vi.runAllTimers();
+    });
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0][0]).toBeInstanceOf(CancelledError);
+    expect(service).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  test('runAsync should reject a queued call when it is superseded', async () => {
+    const service = vi.fn((value: string) => Promise.resolve(value));
+    const onFirstRejected = vi.fn();
+    const onSecondFulfilled = vi.fn();
+
+    act(() => {
+      hook = setUp(service, {
+        manual: true,
+        throttleWait: 100,
+        throttleLeading: false,
+      });
+    });
+    hook.rerender();
+
+    await act(async () => {
+      hook.result.current.runAsync('first').catch(onFirstRejected);
+      hook.result.current.runAsync('second').then(onSecondFulfilled);
+      vi.runAllTimers();
+    });
+
+    expect(onFirstRejected).toHaveBeenCalledTimes(1);
+    expect(onFirstRejected.mock.calls[0][0]).toBeInstanceOf(CancelledError);
+    expect(service).toHaveBeenCalledTimes(1);
+    expect(service).toHaveBeenCalledWith('second');
+    expect(onSecondFulfilled).toHaveBeenCalledWith('second');
+    hook.unmount();
   });
 });

--- a/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.en-US.md
@@ -112,6 +112,33 @@ At the same time, `useRequest` will automatically ignore the response at the fol
 
 <code src="./demo/cancel.tsx" />
 
+### What an ignored request returns
+
+An ignored request never updates `data`/`error`, and never triggers `onSuccess`/`onError`/`onFinally`.
+
+For `run` and `refresh` that is the whole story: they report nothing.
+
+For `runAsync` and `refreshAsync` the promise **rejects with a `CancelledError`**, so that `await`,
+`.finally()` and any lock around the call are always released. Use `isCancelledError` to tell an
+ignored request apart from a real failure:
+
+```ts
+import { isCancelledError } from 'ahooks';
+
+try {
+  await runAsync();
+  // only reached when this call actually won
+} catch (error) {
+  if (isCancelledError(error)) {
+    return; // cancelled or superseded, `data` belongs to another call
+  }
+  handle(error);
+}
+```
+
+Note that the value of an ignored request is dropped: a superseded call rejects with a
+`CancelledError` even when its own promise rejected with a service error.
+
 ## Parameter management
 
 The `params` returned by `useRequest` will record the parameters of `service`. For example, if you trigger `run(1, 2, 3)`, then `params` is equal to `[1, 2, 3]`.

--- a/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
+++ b/packages/hooks/src/useRequest/doc/basic/basic.zh-CN.md
@@ -112,6 +112,32 @@ return (
 
 <code src="./demo/cancel.tsx" />
 
+### 被忽略的请求会返回什么
+
+被忽略的请求不会更新 `data`/`error`，也不会触发 `onSuccess`/`onError`/`onFinally`。
+
+对于 `run` 和 `refresh` 来说到此为止：它们不会报告任何东西。
+
+对于 `runAsync` 和 `refreshAsync`，其 promise 会**以 `CancelledError` reject**，从而保证 `await`、
+`.finally()` 以及调用外层的锁一定会被释放。可以用 `isCancelledError` 区分「被忽略」和「真正失败」：
+
+```ts
+import { isCancelledError } from 'ahooks';
+
+try {
+  await runAsync();
+  // 只有本次调用真正胜出时才会执行到这里
+} catch (error) {
+  if (isCancelledError(error)) {
+    return; // 被取消或被更新的调用覆盖，此时 data 属于另一次调用
+  }
+  handle(error);
+}
+```
+
+注意：被忽略的请求，其结果会被丢弃。即使它自身的 promise 是以 service 错误 reject 的，
+被覆盖的调用也只会以 `CancelledError` reject。
+
 ## 参数管理
 
 `useRequest` 返回的 `params` 会记录当次调用 `service` 的参数数组。比如你触发了 `run(1, 2, 3)`，则 `params` 等于 `[1, 2, 3]` 。

--- a/packages/hooks/src/useRequest/index.ts
+++ b/packages/hooks/src/useRequest/index.ts
@@ -1,6 +1,7 @@
 import useRequest from './src/useRequest';
 import { clearCache } from './src/utils/cache';
+import { CancelledError, isCancelledError } from './src/utils/cancelledError';
 
-export { clearCache };
+export { CancelledError, clearCache, isCancelledError };
 
 export default useRequest;

--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -2,6 +2,7 @@
 import type { RefObject } from 'react';
 import { isFunction } from '../../utils';
 import type { FetchState, Options, PluginReturn, Service, Subscribe } from './types';
+import { CancelledError, isCancelledError } from './utils/cancelledError';
 
 export default class Fetch<TData, TParams extends any[]> {
   pluginImpls: PluginReturn<TData, TParams>[] = [];
@@ -81,9 +82,7 @@ export default class Fetch<TData, TParams extends any[]> {
       const res = await servicePromise;
 
       if (currentCount !== this.count) {
-        // superseded: settle with current data (not the stale `res`) so
-        // `finally`/locks don't hang and a direct `.then` can't clobber fresher state
-        return Promise.resolve(this.state.data as TData);
+        throw new CancelledError();
       }
 
       // const formattedResult = this.options.formatResultRef.current ? this.options.formatResultRef.current(res) : res;
@@ -106,8 +105,7 @@ export default class Fetch<TData, TParams extends any[]> {
       return res;
     } catch (error) {
       if (currentCount !== this.count) {
-        // superseded: settle so `finally`/locks don't hang; the stale error is dropped
-        return Promise.resolve(this.state.data as TData);
+        throw isCancelledError(error) ? error : new CancelledError();
       }
 
       this.setState({
@@ -130,6 +128,11 @@ export default class Fetch<TData, TParams extends any[]> {
 
   run(...params: TParams) {
     this.runAsync(...params).catch((error) => {
+      // cancellation is not a failure: `run` never reports it
+      if (isCancelledError(error)) {
+        return;
+      }
+
       if (!this.options.onError) {
         console.error(error);
       }

--- a/packages/hooks/src/useRequest/src/Fetch.ts
+++ b/packages/hooks/src/useRequest/src/Fetch.ts
@@ -81,8 +81,9 @@ export default class Fetch<TData, TParams extends any[]> {
       const res = await servicePromise;
 
       if (currentCount !== this.count) {
-        // prevent run.then when request is canceled
-        return new Promise(() => {});
+        // superseded: settle with current data (not the stale `res`) so
+        // `finally`/locks don't hang and a direct `.then` can't clobber fresher state
+        return Promise.resolve(this.state.data as TData);
       }
 
       // const formattedResult = this.options.formatResultRef.current ? this.options.formatResultRef.current(res) : res;
@@ -105,8 +106,8 @@ export default class Fetch<TData, TParams extends any[]> {
       return res;
     } catch (error) {
       if (currentCount !== this.count) {
-        // prevent run.then when request is canceled
-        return new Promise(() => {});
+        // superseded: settle so `finally`/locks don't hang; the stale error is dropped
+        return Promise.resolve(this.state.data as TData);
       }
 
       this.setState({

--- a/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
@@ -2,12 +2,14 @@ import type { DebouncedFunc, DebounceSettings } from 'lodash';
 import debounce from 'lodash/debounce';
 import { useEffect, useMemo, useRef } from 'react';
 import type { Plugin } from '../types';
+import { cancelPendingPromise } from '../utils/cancelledError';
 
 const useDebouncePlugin: Plugin<any, any[]> = (
   fetchInstance,
   { debounceWait, debounceLeading, debounceTrailing, debounceMaxWait },
 ) => {
   const debouncedRef = useRef<DebouncedFunc<any>>(undefined);
+  const pendingRejectRef = useRef<(reason?: any) => void>(undefined);
 
   const options = useMemo(() => {
     const ret: DebounceSettings = {};
@@ -38,8 +40,12 @@ const useDebouncePlugin: Plugin<any, any[]> = (
       // debounce runAsync should be promise
       // https://github.com/lodash/lodash/issues/4400#issuecomment-834800398
       fetchInstance.runAsync = (...args) => {
+        cancelPendingPromise(pendingRejectRef);
+
         return new Promise<void>((resolve, reject) => {
+          pendingRejectRef.current = reject;
           debouncedRef.current?.(() => {
+            pendingRejectRef.current = undefined;
             _originRunAsync(...args)
               .then(resolve)
               .catch(reject);
@@ -49,6 +55,7 @@ const useDebouncePlugin: Plugin<any, any[]> = (
 
       return () => {
         debouncedRef.current?.cancel();
+        cancelPendingPromise(pendingRejectRef);
         fetchInstance.runAsync = _originRunAsync;
       };
     }
@@ -61,6 +68,7 @@ const useDebouncePlugin: Plugin<any, any[]> = (
   return {
     onCancel: () => {
       debouncedRef.current?.cancel();
+      cancelPendingPromise(pendingRejectRef);
     },
   };
 };

--- a/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useDebouncePlugin.ts
@@ -10,7 +10,7 @@ const useDebouncePlugin: Plugin<any, any[]> = (
   { debounceWait, debounceLeading, debounceTrailing, debounceMaxWait, ready },
 ) => {
   const debouncedRef = useRef<DebouncedFunc<any>>(undefined);
-  const pendingRejectRef = useRef<(reason?: any) => void>(undefined);
+  const pendingRejectRef = useRef<(reason?: unknown) => void>(undefined);
 
   const options = useMemo(() => {
     const ret: DebounceSettings = {};
@@ -48,13 +48,19 @@ const useDebouncePlugin: Plugin<any, any[]> = (
         cancelPendingPromise(pendingRejectRef);
 
         return new Promise<void>((resolve, reject) => {
+          let callbackInvoked = false;
           pendingRejectRef.current = reject;
           debouncedRef.current?.(() => {
+            callbackInvoked = true;
             pendingRejectRef.current = undefined;
             _originRunAsync(...args)
               .then(resolve)
               .catch(reject);
           });
+
+          if (!callbackInvoked && options.trailing === false) {
+            cancelPendingPromise(pendingRejectRef);
+          }
         });
       };
 

--- a/packages/hooks/src/useRequest/src/plugins/useThrottlePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useThrottlePlugin.ts
@@ -2,12 +2,14 @@ import type { DebouncedFunc, ThrottleSettings } from 'lodash';
 import throttle from 'lodash/throttle';
 import { useEffect, useRef } from 'react';
 import type { Plugin } from '../types';
+import { cancelPendingPromise } from '../utils/cancelledError';
 
 const useThrottlePlugin: Plugin<any, any[]> = (
   fetchInstance,
   { throttleWait, throttleLeading, throttleTrailing },
 ) => {
   const throttledRef = useRef<DebouncedFunc<any>>(undefined);
+  const pendingRejectRef = useRef<(reason?: any) => void>(undefined);
 
   const options: ThrottleSettings = {};
 
@@ -33,8 +35,12 @@ const useThrottlePlugin: Plugin<any, any[]> = (
       // throttle runAsync should be promise
       // https://github.com/lodash/lodash/issues/4400#issuecomment-834800398
       fetchInstance.runAsync = (...args) => {
+        cancelPendingPromise(pendingRejectRef);
+
         return new Promise((resolve, reject) => {
+          pendingRejectRef.current = reject;
           throttledRef.current?.(() => {
+            pendingRejectRef.current = undefined;
             _originRunAsync(...args)
               .then(resolve)
               .catch(reject);
@@ -45,6 +51,7 @@ const useThrottlePlugin: Plugin<any, any[]> = (
       return () => {
         fetchInstance.runAsync = _originRunAsync;
         throttledRef.current?.cancel();
+        cancelPendingPromise(pendingRejectRef);
       };
     }
   }, [throttleWait, throttleLeading, throttleTrailing]);
@@ -56,6 +63,7 @@ const useThrottlePlugin: Plugin<any, any[]> = (
   return {
     onCancel: () => {
       throttledRef.current?.cancel();
+      cancelPendingPromise(pendingRejectRef);
     },
   };
 };

--- a/packages/hooks/src/useRequest/src/plugins/useThrottlePlugin.ts
+++ b/packages/hooks/src/useRequest/src/plugins/useThrottlePlugin.ts
@@ -9,7 +9,7 @@ const useThrottlePlugin: Plugin<any, any[]> = (
   { throttleWait, throttleLeading, throttleTrailing },
 ) => {
   const throttledRef = useRef<DebouncedFunc<any>>(undefined);
-  const pendingRejectRef = useRef<(reason?: any) => void>(undefined);
+  const pendingRejectRef = useRef<(reason?: unknown) => void>(undefined);
 
   const options: ThrottleSettings = {};
 
@@ -38,13 +38,19 @@ const useThrottlePlugin: Plugin<any, any[]> = (
         cancelPendingPromise(pendingRejectRef);
 
         return new Promise((resolve, reject) => {
+          let callbackInvoked = false;
           pendingRejectRef.current = reject;
           throttledRef.current?.(() => {
+            callbackInvoked = true;
             pendingRejectRef.current = undefined;
             _originRunAsync(...args)
               .then(resolve)
               .catch(reject);
           });
+
+          if (!callbackInvoked && options.trailing === false) {
+            cancelPendingPromise(pendingRejectRef);
+          }
         });
       };
 

--- a/packages/hooks/src/useRequest/src/utils/cancelledError.ts
+++ b/packages/hooks/src/useRequest/src/utils/cancelledError.ts
@@ -1,5 +1,9 @@
 const CANCELLED_ERROR_FLAG = '__AHOOKS_CANCELLED_ERROR__';
 
+interface PendingPromiseRef {
+  current: ((reason?: any) => void) | undefined;
+}
+
 /**
  * Rejection reason used when `useRequest` ignores a request, either because
  * `cancel()` was called (or the component unmounted), or because a newer call superseded it.
@@ -26,4 +30,9 @@ export function isCancelledError(error: unknown): error is CancelledError {
       error !== null &&
       (error as Record<string, unknown>)[CANCELLED_ERROR_FLAG] === true)
   );
+}
+
+export function cancelPendingPromise(pendingRejectRef: PendingPromiseRef) {
+  pendingRejectRef.current?.(new CancelledError());
+  pendingRejectRef.current = undefined;
 }

--- a/packages/hooks/src/useRequest/src/utils/cancelledError.ts
+++ b/packages/hooks/src/useRequest/src/utils/cancelledError.ts
@@ -1,7 +1,7 @@
 const CANCELLED_ERROR_FLAG = '__AHOOKS_CANCELLED_ERROR__';
 
 interface PendingPromiseRef {
-  current: ((reason?: any) => void) | undefined;
+  current: ((reason?: unknown) => void) | undefined;
 }
 
 /**

--- a/packages/hooks/src/useRequest/src/utils/cancelledError.ts
+++ b/packages/hooks/src/useRequest/src/utils/cancelledError.ts
@@ -1,0 +1,29 @@
+const CANCELLED_ERROR_FLAG = '__AHOOKS_CANCELLED_ERROR__';
+
+/**
+ * Rejection reason used when `useRequest` ignores a request, either because
+ * `cancel()` was called (or the component unmounted), or because a newer call superseded it.
+ *
+ * It is swallowed by `run`/`refresh`, by `options.onError` and by the plugin `onError`
+ * handlers, so it only surfaces to code that awaits `runAsync`/`refreshAsync` directly.
+ */
+export class CancelledError extends Error {
+  /** Marker that survives duplicated copies of the module, unlike `instanceof`. */
+  readonly [CANCELLED_ERROR_FLAG] = true;
+
+  constructor(message = 'useRequest: the request was cancelled or superseded.') {
+    super(message);
+    this.name = 'CancelledError';
+    // keep `instanceof` working when the class is downleveled
+    Object.setPrototypeOf(this, CancelledError.prototype);
+  }
+}
+
+export function isCancelledError(error: unknown): error is CancelledError {
+  return (
+    error instanceof CancelledError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      (error as Record<string, unknown>)[CANCELLED_ERROR_FLAG] === true)
+  );
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Sibling of #2866.

This PR fixes the remaining count-based cancellation path in `Fetch.runAsync`, as well as pending promises created by the debounce and throttle wrappers when a queued call is cancelled or superseded before `_originRunAsync` starts.

### 💡 Background and solution

`runAsync` returns a promise that never settles when its request is superseded by a newer `run` / `runAsync` call or by `cancel()`:

```ts
const res = await servicePromise;

if (currentCount !== this.count) {
  return new Promise(() => {});
}
```

Even after the underlying service promise settles, the ignored `runAsync` promise remains pending forever. As a result, `.finally()` callbacks do not run and cleanup mechanisms such as `useLockFn`, semaphores, loading flags, and in-flight counters may never be released.

A reproduction of the resulting deadlock:

```ts
import { act, renderHook } from '@testing-library/react';
import { vi } from 'vitest';
import { useLockFn, useRequest } from 'ahooks';

it('useLockFn releases its lock after a request is superseded', async () => {
  const service = vi.fn().mockResolvedValue('data');
  const calls: string[] = [];

  const { result } = renderHook(() => {
    const { runAsync } = useRequest(service, { manual: true });
    const guarded = useLockFn(async () => {
      calls.push('enter');
      try {
        await runAsync();
      } finally {
        calls.push('leave');
      }
    });

    return { guarded, runAsync };
  });

  await act(async () => {
    void result.current.guarded().catch(() => {});
    await result.current.runAsync(); // supersedes the guarded call
  });

  await act(async () => {
    await result.current.guarded();
  });

  expect(calls).toEqual(['enter', 'leave', 'enter', 'leave']);
  // Before the fix: ['enter'] — the first promise never settles,
  // so neither the callback's finally nor useLockFn's finally can release the lock.
});
```

This PR defines the cancellation contract explicitly:

- `runAsync` and `refreshAsync` reject with a dedicated `CancelledError` when their request is ignored after being cancelled or superseded;
- `isCancelledError(error)` allows consumers to distinguish cancellation from a service failure;
- `run` and `refresh` silently ignore `CancelledError`;
- cancellation does not update `data` or `error`;
- cancellation does not trigger `onSuccess`, `onError`, or internal `onFinally` handlers;
- the stale response or service error remains ignored;
- the winning request is unaffected.

```ts
import { isCancelledError } from 'ahooks';

try {
  await runAsync();
} catch (error) {
  if (isCancelledError(error)) {
    return;
  }

  handleError(error);
}
```

This is an observable behavior change for `runAsync` consumers: an ignored call now rejects instead of remaining pending forever. Consumers that handle `runAsync` failures should ignore `CancelledError` when cancellation is expected. Fire-and-forget `run` consumers are unaffected.

The regression tests cover:

1. An explicit `cancel()` call.
2. The superseded request settling before the newer request.
3. The newer request settling before the superseded request.
4. The exact rejection type and value.
5. `.then()`, `.catch()`, and `.finally()` behavior after cancellation.
6. A superseded service rejection being reported as cancellation rather than as a stale service error.
7. `run` remaining silent after cancellation.
8. Queued debounce and throttle calls being cancelled before the service starts.
9. Queued debounce and throttle calls being superseded by a newer call.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `useRequest`: cancelled or superseded `runAsync` and `refreshAsync` calls now reject with `CancelledError` instead of remaining pending forever. `run` and `refresh` silently ignore cancellation. |
| 🇨🇳 Chinese | 修复 `useRequest`：被取消或被后续调用覆盖的 `runAsync` 和 `refreshAsync` 现在会以 `CancelledError` reject，不再永久 pending；`run` 和 `refresh` 会静默忽略取消。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
