### PR TITLE
fix: repair invalid yaml in issue close workflow

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -21,13 +21,11 @@ jobs:
             const targets = [
               {
                 label: '🤔 Need Reproduce',
-                body: `Since the issue was labeled with \`🤔 Need Reproduce\`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.
-由于该 issue 被标记为需要重现（🤔 Need Reproduce），却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。`,
+                body: 'Since the issue was labeled with `🤔 Need Reproduce`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.\n由于该 issue 被标记为需要重现（🤔 Need Reproduce），却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。',
               },
               {
                 label: 'needs more info',
-                body: `Since the issue was labeled with \`needs more info\`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.
-由于该 issue 被标记为需要更多信息，却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。`,
+                body: 'Since the issue was labeled with `needs more info`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.\n由于该 issue 被标记为需要更多信息，却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。',
               },
             ];
 


### PR DESCRIPTION
## 问题

合并 PR #2946 时 GitHub 报错:

> Invalid workflow file
> You have an error in your yaml syntax on line 25 in .github/workflows/issue-close-require.yml

## 原因

提交 0df187e8（经 PR #2941 合入）把 workflow 重写为 `actions/github-script@v7` 版本，其中两处 `body` 的中文续行写成了**零缩进（顶格）**。这导致 YAML 的 `script: |` 字面量块标量提前结束，后面的 `},` 被当作 YAML 结构解析，触发语法错误（line 25）。

## 修复

将两处多行模板字符串改为**单行 JS 字符串 + `\n` 换行**，彻底避免多行 YAML 标量的缩进陷阱：

```js
body: 'Since the issue was labeled with `🤔 Need Reproduce`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.\n由于该 issue 被标记为需要重现（🤔 Need Reproduce），却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。',
```

已通过 `ruby -ryaml` 解析校验，YAML OK。

> 该分支基于最新 origin/master（含 PR #2946 的合并），无冲突。