### PR TITLE
feat(useAsyncEffect): support synchronous cleanup functions

### DIFF
--- a/packages/hooks/src/useAsyncEffect/__tests__/index.spec.ts
+++ b/packages/hooks/src/useAsyncEffect/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { sleep } from '../../utils/testingHelpers';
 import useAsyncEffect from '../index';
 
@@ -66,5 +66,33 @@ describe('useAsyncEffect', () => {
       await sleep(50);
     });
     expect(hook.result.current.y).toBe(3);
+  });
+
+  test('should run a synchronous cleanup on unmount', () => {
+    const cleanup = vi.fn();
+    const hook = renderHook(() => {
+      useAsyncEffect(() => cleanup, []);
+    });
+
+    expect(cleanup).not.toHaveBeenCalled();
+    hook.unmount();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('should clean up before rerunning after a dependency change', () => {
+    const cleanups = [vi.fn(), vi.fn()];
+    const hook = renderHook(
+      ({ index }) => {
+        useAsyncEffect(() => cleanups[index], [index]);
+      },
+      { initialProps: { index: 0 } },
+    );
+
+    hook.rerender({ index: 1 });
+    expect(cleanups[0]).toHaveBeenCalledTimes(1);
+    expect(cleanups[1]).not.toHaveBeenCalled();
+
+    hook.unmount();
+    expect(cleanups[1]).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hooks/src/useAsyncEffect/index.en-US.md
+++ b/packages/hooks/src/useAsyncEffect/index.en-US.md
@@ -21,7 +21,7 @@ useEffect support async function.
 
 ```typescript
 function useAsyncEffect(
-  effect: () => AsyncGenerator | Promise,
+  effect: () => AsyncGenerator | Promise<void> | (() => void),
   deps: DependencyList
 );
 ```

--- a/packages/hooks/src/useAsyncEffect/index.ts
+++ b/packages/hooks/src/useAsyncEffect/index.ts
@@ -9,22 +9,26 @@ function isAsyncGenerator(
 }
 
 function useAsyncEffect(
-  effect: () => AsyncGenerator<void, void, void> | Promise<void>,
+  effect: () => AsyncGenerator<void, void, void> | Promise<void> | (() => void),
   deps?: DependencyList,
 ) {
   useEffect(() => {
     const e = effect();
+    if (typeof e === 'function') {
+      return e;
+    }
+    const asyncEffect = e;
     let cancelled = false;
     async function execute() {
-      if (isAsyncGenerator(e)) {
+      if (isAsyncGenerator(asyncEffect)) {
         while (true) {
-          const result = await e.next();
+          const result = await asyncEffect.next();
           if (result.done || cancelled) {
             break;
           }
         }
       } else {
-        await e;
+        await asyncEffect;
       }
     }
     execute();

--- a/packages/hooks/src/useAsyncEffect/index.zh-CN.md
+++ b/packages/hooks/src/useAsyncEffect/index.zh-CN.md
@@ -21,7 +21,7 @@ useEffect 支持异步函数。
 
 ```typescript
 function useAsyncEffect(
-  effect: () => AsyncGenerator | Promise,
+  effect: () => AsyncGenerator | Promise<void> | (() => void),
   deps: DependencyList
 );
 ```


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Closes #2954

### 💡 Background and solution

`useAsyncEffect` currently accepts promises and async generators, but callers cannot return a normal React cleanup function. The hook now detects a synchronous function result and returns it directly from `useEffect`, preserving React's standard cleanup timing on dependency changes and unmount.

The asynchronous promise/generator cancellation path is unchanged.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `useAsyncEffect` now supports returning a synchronous cleanup function. |
| 🇨🇳 Chinese | `useAsyncEffect` 现在支持返回同步清理函数。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Validation

- `vitest run packages/hooks/src/useAsyncEffect/__tests__/index.spec.ts` (4 tests)
- `tsc --noEmit -p packages/hooks/tsconfig.json`
- Biome formatting check for the four changed files
- `git diff --check`

### AI assistance

Codex assisted with implementation, type-checking, and tests. I reviewed the complete diff and take responsibility for the change.
