### PR TITLE
chore: release ahooks 3.10.0

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ahooks",
-  "version": "3.9.7",
+  "version": "3.10.0",
   "description": "react hooks library",
   "keywords": [
     "ahooks",


### PR DESCRIPTION
Bump `ahooks` from 3.9.7 to 3.10.0 to release the changes already merged into master. Only `packages/hooks/package.json` changes; `@ahooks.js/use-url-state` is not bumped or republished.

The release includes synchronous cleanup support in `useAsyncEffect`, optional initial state in `useSetState`, SSR-safe storage initialization, ProForm transform support, and the merged request, scrolling, keyboard, ref-type and compatibility fixes. Cancelled or superseded `runAsync` / `refreshAsync` calls now reject with `CancelledError`; the release notes will highlight this behavior.

Validation with Node 22.23.2 and pnpm 10.12.4:
- Clean dependency installation with no lockfile changes.
- `pnpm run build` and `pnpm run tsc` passed.
- `pnpm run test` and `pnpm run test:strict` passed: 401 hooks tests and 8 use-url-state tests in each mode.
- `pnpm run build:doc` passed.
- Installed the actual `ahooks-3.10.0.tgz` in an isolated consumer and verified CommonJS exports, bundled ESM, standalone UMD, historical entry paths, metadata and TypeScript consumer usage.
- Package JSON formatting, commit message and `git diff --check` passed.

After merge, publish `ahooks@3.10.0` from the merge commit, deploy the main documentation site, verify the GitHub Pages mirror, and create the matching tag and bilingual GitHub Release.
